### PR TITLE
Improve docs and frontend handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # cdb-form
-Plugin de formularios personalizados para proyectocdb.es
+
+Plugin de formularios personalizados para [proyectocdb.es](https://proyectocdb.es).
+
+## Instalación
+
+1. Copia la carpeta `cdb-form` en el directorio `wp-content/plugins` de tu instalación de WordPress.
+2. Activa el plugin desde el panel de administración.
+3. Al activarlo se crearán las tablas necesarias y se registrarán los CPT utilizados.
+
+## Uso básico
+
+El plugin proporciona varios *shortcodes* para mostrar formularios y listados. Los más relevantes son:
+
+- `[cdb_form_bar]` – formulario para crear o editar la información de un bar.
+- `[cdb_form_empleado]` – formulario para crear o actualizar un empleado.
+- `[cdb_form_experiencia]` – gestión de la experiencia laboral.
+
+Inserta cualquiera de estos shortcodes en una página o entrada para mostrar el formulario correspondiente.
+
+## Desarrollo
+
+El código se encuentra dividido en carpetas lógicas (`includes`, `templates`, `assets`).
+Los scripts de JavaScript del frontend se cargan desde `assets/js/frontend-scripts.js`.
+
+Para más información consulta la carpeta `docs/`.

--- a/assets/js/frontend-scripts.js
+++ b/assets/js/frontend-scripts.js
@@ -30,34 +30,46 @@ jQuery(document).ready(function($) {
         });
     });
 
-    // 🔹 Manejo de actualización del estado del bar
-    $('#cdb-update-estado-bar').on('submit', function(e) {
+    // 🔹 Manejo del formulario de bar (crear/actualizar)
+    $('#cdb-form-bar').on('submit', function(e) {
         e.preventDefault();
 
-        var form = $(this);
-        var formData = form.serialize();
+        var formData = {
+            action: 'cdb_actualizar_estado_bar',
+            security: $('#security').val(),
+            bar_id: $('input[name="bar_id"]').val(),
+            estado: $('#estado').val()
+        };
 
-        console.log("Datos enviados (Bar):", formData); // Depuración en consola
-
-        $.ajax({
-            type: 'POST',
-            url: cdb_form_ajax.ajaxurl,
-            data: formData + '&action=cdb_actualizar_estado_bar',
-            dataType: 'json',
-            success: function(response) {
-                console.log("Respuesta AJAX (Bar):", response); // Depuración en consola
-
-                if (response.success) {
-                    alert('Estado del bar actualizado correctamente.');
-                    location.reload();
-                } else {
-                    alert('Error: ' + response.data.message);
-                }
-            },
-            error: function(jqXHR, textStatus, errorThrown) {
-                console.error("Error AJAX (Bar):", textStatus, errorThrown);
-                alert('Hubo un problema al actualizar el estado del bar.');
+        $.post(cdb_form_ajax.ajaxurl, formData, function(response) {
+            alert(response.message);
+            if (response.success) {
+                location.reload();
             }
+        }, 'json');
+    });
+
+    // 🔹 Manejo del formulario de empleado
+    $('#cdb-form-empleado').on('submit', function(e) {
+        e.preventDefault();
+
+        var formData = {
+            action: 'cdb_form_empleado_submit',
+            security: $('#security').val(),
+            empleado_id: $('input[name="empleado_id"]').val(),
+            nombre: $('#nombre').val(),
+            disponible: $('#disponible').val()
+        };
+
+        $.post(cdb_form_ajax.ajaxurl, formData, function(response) {
+            if (response.success) {
+                alert(response.message || 'Perfil de empleado actualizado con éxito.');
+                location.reload();
+            } else {
+                alert(response.message || 'Hubo un error inesperado.');
+            }
+        }, 'json').fail(function(jqXHR, textStatus) {
+            alert('Error en la solicitud: ' + textStatus);
         });
     });
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,8 @@
-# Instrucciones básicas del plugin
+# Documentación del plugin
+
+Este directorio contiene archivos de apoyo para desarrolladores y usuarios avanzados.
+
+- **changelog.txt** – registro de cambios y versiones del plugin.
+- **manual.pdf** – guía detallada de instalación y uso.
+
+Para instrucciones rápidas consulta el archivo principal `README.md` en la raíz del proyecto.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,1 +1,7 @@
 # Registro de cambios y versiones
+
+## 1.0.1
+- Unificación de funciones AJAX de experiencia.
+- Mejora de validaciones al obtener los años del bar.
+- Separación de scripts JavaScript en `assets/js/frontend-scripts.js`.
+- Actualización de documentación.

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -142,104 +142,34 @@ if ( ! function_exists( 'cdb_obtener_anios_bar' ) ) {
         if ( ! isset( $_GET['bar_id'] ) ) {
             wp_send_json_error( array( 'message' => 'Bar ID no proporcionado.' ) );
         }
-        
-        $bar_id         = intval( $_GET['bar_id'] );
+
+        $bar_id = intval( $_GET['bar_id'] );
+        if ( ! $bar_id ) {
+            wp_send_json_error( array( 'message' => 'ID de bar inválido.' ) );
+        }
+
         $fecha_apertura = get_post_meta( $bar_id, '_cdb_bar_apertura', true );
         $fecha_cierre   = get_post_meta( $bar_id, '_cdb_bar_cierre', true );
-        
+
         if ( ! $fecha_apertura ) {
             wp_send_json_error( array( 'message' => 'No se encontraron fechas para este bar.' ) );
         }
-        
+
         $fecha_apertura = intval( $fecha_apertura );
-        $fecha_cierre = $fecha_cierre ? intval( $fecha_cierre ) : '';
-        
+        $fecha_cierre   = $fecha_cierre !== '' ? intval( $fecha_cierre ) : '';
+
+        if ( $fecha_cierre && $fecha_cierre < $fecha_apertura ) {
+            wp_send_json_error( array( 'message' => 'La fecha de cierre es anterior a la de apertura.' ) );
+        }
+
         wp_send_json_success( array(
             'fecha_apertura' => $fecha_apertura,
-            'fecha_cierre'   => $fecha_cierre
+            'fecha_cierre'   => $fecha_cierre,
         ) );
         wp_die();
     }
 }
 add_action( 'wp_ajax_cdb_obtener_anios_bar', 'cdb_obtener_anios_bar' );
-
-/**
- * Guarda una experiencia laboral.
- *
- * Se esperan los parámetros POST 'empleado_id', 'bar_id', 'anio' y 'posicion_id'.
- * Tras la inserción, se vincula con el equipo correspondiente, se integra la puntuación de la zona
- * (sumándola a la puntuación de la posición) y se actualiza el meta "cdb_experiencia_score".
- */
-if ( ! function_exists( 'cdb_guardar_experiencia' ) ) {
-    function cdb_guardar_experiencia() {
-        if ( ! is_user_logged_in() ) {
-            wp_send_json_error( array( 'message' => 'No tienes permisos.' ) );
-        }
-        if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( $_POST['security'], 'cdb_form_nonce' ) ) {
-            wp_send_json_error( array( 'message' => 'Error de seguridad.' ) );
-        }
-        
-        $empleado_id = intval( $_POST['empleado_id'] );
-        $bar_id      = intval( $_POST['bar_id'] );
-        $anio        = intval( $_POST['anio'] );
-        $posicion_id = intval( $_POST['posicion_id'] );
-        
-        global $wpdb;
-        $tabla_exp = $wpdb->prefix . 'cdb_experiencia';
-        
-        $resultado_insert = $wpdb->insert(
-            $tabla_exp,
-            array(
-                'empleado_id' => $empleado_id,
-                'bar_id'      => $bar_id,
-                'anio'        => $anio,
-                'posicion_id' => $posicion_id,
-            ),
-            array( '%d', '%d', '%d', '%d' )
-        );
-        
-        if ( $resultado_insert ) {
-            // Vincular con el equipo (bar + año) si es posible.
-            if ( function_exists('cdb_get_or_create_equipo') ) {
-                $equipo_id = cdb_get_or_create_equipo( $bar_id, $anio );
-                update_post_meta( $empleado_id, '_cdb_empleado_equipo', $equipo_id );
-                update_post_meta( $empleado_id, '_cdb_empleado_year', $anio );
-                update_post_meta( $empleado_id, '_cdb_empleado_bar', $bar_id );
-            }
-            
-            /**
-             * Integración de la puntuación de la zona:
-             * - Se obtiene la puntuación de la posición asociada (ya almacenada en _cdb_posiciones_score).
-             * - Se obtiene la puntuación de la zona asignada al Bar.
-             * - Se suman ambas para obtener la puntuación total de la experiencia.
-             */
-            $puntuacion_posicion = get_post_meta( $posicion_id, '_cdb_posiciones_score', true );
-            $puntuacion_posicion = intval( $puntuacion_posicion );
-            
-            $puntuacion_zona = 0;
-            if ( $bar_id ) {
-                $zona_id = get_post_meta( $bar_id, '_cdb_bar_zona_id', true );
-                if ( $zona_id ) {
-                    $puntuacion_zona = get_post_meta( $zona_id, 'puntuacion_zona', true );
-                    $puntuacion_zona = intval( $puntuacion_zona );
-                }
-            }
-            $experiencia_total = $puntuacion_posicion + $puntuacion_zona;
-            
-            // Se podría guardar este valor en un meta field propio de la experiencia si fuera necesario.
-            // update_post_meta( $experiencia_id, '_cdb_experiencia_total', $experiencia_total );
-            
-            // Actualizar el meta "cdb_experiencia_score" del empleado.
-            cdb_actualizar_experiencia_score( $empleado_id );
-            wp_send_json_success( array( 'message' => 'Experiencia guardada correctamente.', 'experiencia_total' => $experiencia_total ) );
-        } else {
-            wp_send_json_error( array( 'message' => 'No se pudo guardar la experiencia.' ) );
-        }
-        wp_die();
-    }
-}
-add_action( 'wp_ajax_cdb_guardar_experiencia', 'cdb_guardar_experiencia' );
-add_action( 'wp_ajax_nopriv_cdb_guardar_experiencia', 'cdb_guardar_experiencia' );
 
 /**
  * Borra una experiencia laboral.

--- a/templates/form-bar-template.php
+++ b/templates/form-bar-template.php
@@ -26,10 +26,10 @@ if (!empty($existing_bar)) {
     <?php wp_nonce_field( 'cdb_form_nonce', 'security' ); ?>
     <input type="hidden" name="bar_id" value="<?php echo esc_attr($bar_id); ?>">
 
-    <label for="nombre_bar">Nombre del Bar:</label>
+    <label for="nombre_bar"><?php esc_html_e('Nombre del Bar:', 'cdb-form'); ?></label>
     <input type="text" id="nombre_bar" name="nombre_bar" value="<?php echo esc_attr($bar_nombre); ?>" required>
 
-    <label for="estado">Estado:</label>
+    <label for="estado"><?php esc_html_e('Estado:', 'cdb-form'); ?></label>
     <select id="estado" name="estado">
         <option value="Abierto todo el año" <?php selected($bar_estado, 'Abierto todo el año'); ?>>Abierto todo el año</option>
         <option value="Abierto temporalmente" <?php selected($bar_estado, 'Abierto temporalmente'); ?>>Abierto temporalmente</option>
@@ -39,27 +39,5 @@ if (!empty($existing_bar)) {
         <option value="Desconocido" <?php selected($bar_estado, 'Desconocido'); ?>>Desconocido</option>
     </select>
 
-    <button type="submit">Actualizar</button>
+    <button type="submit"><?php esc_html_e('Actualizar', 'cdb-form'); ?></button>
 </form>
-
-<script>
-jQuery(document).ready(function($) {
-    $('#cdb-form-bar').on('submit', function(e) {
-        e.preventDefault();
-
-        var formData = {
-            action: 'cdb_actualizar_estado_bar',
-            security: $('#security').val(),
-            bar_id: $('input[name="bar_id"]').val(),
-            estado: $('#estado').val()
-        };
-
-        $.post('<?php echo admin_url('admin-ajax.php'); ?>', formData, function(response) {
-            alert(response.message);
-            if (response.success) {
-                location.reload();
-            }
-        }, 'json');
-    });
-});
-</script>

--- a/templates/form-empleado-template.php
+++ b/templates/form-empleado-template.php
@@ -39,10 +39,10 @@ if (!empty($existing_empleado)) {
 
         <input type="hidden" name="empleado_id" value="<?php echo esc_attr($empleado_id); ?>">
 
-        <label for="nombre">Nombre:</label>
+        <label for="nombre"><?php esc_html_e('Nombre:', 'cdb-form'); ?></label>
         <input type="text" id="nombre" name="nombre" value="<?php echo esc_attr($empleado_nombre); ?>" required>
 
-        <label for="disponible">Disponible:</label>
+        <label for="disponible"><?php esc_html_e('Disponible:', 'cdb-form'); ?></label>
         <select id="disponible" name="disponible">
             <option value="1" <?php selected($empleado_disponible, '1'); ?>>Sí</option>
             <option value="0" <?php selected($empleado_disponible, '0'); ?>>No</option>
@@ -108,30 +108,3 @@ if (!empty($existing_empleado)) {
     }
 </style>
 
-<script>
-jQuery(document).ready(function($) {
-    $('#cdb-form-empleado').on('submit', function(e) {
-        e.preventDefault();
-
-        var formData = {
-            action: 'cdb_form_empleado_submit',
-            security: $('#security').val(),
-            empleado_id: $('input[name="empleado_id"]').val(),
-            nombre: $('#nombre').val(),
-            disponible: $('#disponible').val()
-        };
-
-        $.post('<?php echo admin_url('admin-ajax.php'); ?>', formData, function(response) {
-            if (response.success) {
-                alert(response.message || 'Perfil de empleado actualizado con éxito.');
-                location.reload();
-            } else {
-                alert(response.message || 'Hubo un error inesperado.');
-            }
-        }, 'json')
-        .fail(function(jqXHR, textStatus, errorThrown) {
-            alert('Error en la solicitud: ' + textStatus);
-        });
-    });
-});
-</script>


### PR DESCRIPTION
## Summary
- expand README and docs
- document latest changes in changelog
- move frontend scripts to assets and add translations
- remove duplicate AJAX handler and add validation

## Testing
- `php -l $(find . -name '*.php')`

------
https://chatgpt.com/codex/tasks/task_e_68852cbff9f08327859156e1bfb67a06