### PR TITLE
Add dynamic messages for employee form

### DIFF
--- a/assets/css/frontend-styles.css
+++ b/assets/css/frontend-styles.css
@@ -30,3 +30,16 @@
     background: #333;
 }
 
+.cdb-form-message {
+    margin-top: 10px;
+    font-weight: bold;
+}
+
+.cdb-form-message.success {
+    color: green;
+}
+
+.cdb-form-message.error {
+    color: red;
+}
+

--- a/assets/js/frontend-scripts.js
+++ b/assets/js/frontend-scripts.js
@@ -61,15 +61,37 @@ jQuery(document).ready(function($) {
             disponible: $('#disponible').val()
         };
 
+        var messageDiv = $(this).find('.cdb-form-message');
+        messageDiv.hide();
+
         $.post(cdb_form_ajax.ajaxurl, formData, function(response) {
             if (response.success) {
-                alert(response.message || 'Perfil de empleado actualizado con éxito.');
-                location.reload();
+                messageDiv
+                    .removeClass('error')
+                    .addClass('success')
+                    .text(response.data.message || '✅ Empleado creado correctamente.')
+                    .show();
             } else {
-                alert(response.message || 'Hubo un error inesperado.');
+                messageDiv
+                    .removeClass('success')
+                    .addClass('error')
+                    .text(response.data.message || '❌ No se ha podido crear el empleado. Inténtalo de nuevo.')
+                    .show();
             }
-        }, 'json').fail(function(jqXHR, textStatus) {
-            alert('Error en la solicitud: ' + textStatus);
+
+            setTimeout(function() {
+                messageDiv.fadeOut();
+            }, 5000);
+        }, 'json').fail(function() {
+            messageDiv
+                .removeClass('success')
+                .addClass('error')
+                .text('❌ No se ha podido crear el empleado. Inténtalo de nuevo.')
+                .show();
+
+            setTimeout(function() {
+                messageDiv.fadeOut();
+            }, 5000);
         });
     });
 });

--- a/templates/form-empleado-template.php
+++ b/templates/form-empleado-template.php
@@ -49,6 +49,7 @@ if (!empty($existing_empleado)) {
         </select>
 
         <button type="submit"><?php echo esc_html($button_text); ?></button>
+        <div class="cdb-form-message" style="display:none;"></div>
     </form>
 </div>
 


### PR DESCRIPTION
## Summary
- add frontend message container to employee form
- style success and error messages
- show AJAX response messages in JS instead of alert

## Testing
- `php -l templates/form-empleado-template.php`


------
https://chatgpt.com/codex/tasks/task_e_688bf843fd248327bdbba580c93095e4