### PR TITLE
Add logging around wp_insert_post

### DIFF
--- a/includes/form-handler.php
+++ b/includes/form-handler.php
@@ -182,7 +182,18 @@ function cdb_form_empleado_submit() {
         ];
 
         try {
+            if (defined('WP_DEBUG') && WP_DEBUG === true) {
+                error_log('[cdb-form] Datos para wp_insert_post: ' . print_r($post_data, true));
+            }
+
             $empleado_id = wp_insert_post($post_data);
+
+            if (defined('WP_DEBUG') && WP_DEBUG === true) {
+                error_log('[cdb-form] Resultado wp_insert_post: ' . print_r($empleado_id, true));
+                if (is_wp_error($empleado_id)) {
+                    error_log('[cdb-form] WP_Error: ' . $empleado_id->get_error_message());
+                }
+            }
 
             if (is_wp_error($empleado_id) || $empleado_id === 0) {
                 if (defined('WP_DEBUG') && WP_DEBUG === true) {


### PR DESCRIPTION
## Summary
- log wp_insert_post data and result in `cdb_form_empleado_submit`

## Testing
- `php -l includes/form-handler.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_688c029e59ac8327989afc2401228d16