### PR TITLE
Add i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Los formularios funcionan mediante llamadas AJAX a `admin-ajax.php` y se validan
 4. Tras procesar la petición, el manejador devuelve una respuesta JSON que permite recargar la página o actualizar el contenido de forma dinámica.
 
 Para más información consulta la carpeta `docs/`.
+
+## Internacionalización
+
+El plugin carga las traducciones desde la carpeta `languages` mediante `load_plugin_textdomain()` al iniciarse. Para generar el archivo `cdb-form.pot` se utilizan las funciones de internacionalización de WordPress en todo el código.

--- a/cdb-form.php
+++ b/cdb-form.php
@@ -5,6 +5,8 @@
  * Version: 1.8.0
  * Author: CdB_
  * Author URI: https://proyectocdb.es
+ * Text Domain: cdb-form
+ * Domain Path: /languages
  */
 
 // Evitar acceso directo al archivo.
@@ -17,6 +19,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  *---------------------------------------------------------------*/
 define( 'CDB_FORM_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CDB_FORM_URL', plugin_dir_url( __FILE__ ) );
+
+/**
+ * Carga el archivo de traducciones del plugin.
+ */
+function cdb_form_load_textdomain() {
+    load_plugin_textdomain( 'cdb-form', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'plugins_loaded', 'cdb_form_load_textdomain' );
 
 /*---------------------------------------------------------------
  * 2. CARGA OPCIONAL DEL PLUGIN cdb-bar (SI EXISTE)

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -66,13 +66,13 @@ function cdb_actualizar_experiencia_score( $empleado_id ) {
 if ( ! function_exists( 'cdb_actualizar_disponibilidad' ) ) {
     function cdb_actualizar_disponibilidad() {
         if ( ! is_user_logged_in() ) {
-            wp_send_json_error( array( 'message' => 'No tienes permisos para realizar esta acción.' ) );
+            wp_send_json_error( array( 'message' => __( 'No tienes permisos para realizar esta acción.', 'cdb-form' ) ) );
         }
         if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( $_POST['security'], 'cdb_form_nonce' ) ) {
-            wp_send_json_error( array( 'message' => 'Error de seguridad.' ) );
+            wp_send_json_error( array( 'message' => __( 'Error de seguridad.', 'cdb-form' ) ) );
         }
         if ( ! isset( $_POST['empleado_id'] ) || ! isset( $_POST['disponible'] ) ) {
-            wp_send_json_error( array( 'message' => 'Datos inválidos.' ) );
+            wp_send_json_error( array( 'message' => __( 'Datos inválidos.', 'cdb-form' ) ) );
         }
         
         $empleado_id  = intval( $_POST['empleado_id'] );
@@ -81,14 +81,14 @@ if ( ! function_exists( 'cdb_actualizar_disponibilidad' ) ) {
         $empleado     = get_post( $empleado_id );
         
         if ( ! $empleado || $empleado->post_author != $current_user->ID ) {
-            wp_send_json_error( array( 'message' => 'No tienes permisos para editar este empleado.' ) );
+            wp_send_json_error( array( 'message' => __( 'No tienes permisos para editar este empleado.', 'cdb-form' ) ) );
         }
         
         $resultado = update_post_meta( $empleado_id, 'disponible', $disponible );
         if ( $resultado !== false ) {
-            wp_send_json_success( array( 'message' => 'Disponibilidad actualizada correctamente.' ) );
+            wp_send_json_success( array( 'message' => __( 'Disponibilidad actualizada correctamente.', 'cdb-form' ) ) );
         } else {
-            wp_send_json_error( array( 'message' => 'Error al actualizar la disponibilidad.' ) );
+            wp_send_json_error( array( 'message' => __( 'Error al actualizar la disponibilidad.', 'cdb-form' ) ) );
         }
         wp_die();
     }
@@ -103,13 +103,13 @@ add_action( 'wp_ajax_cdb_actualizar_disponibilidad', 'cdb_actualizar_disponibili
 if ( ! function_exists( 'cdb_actualizar_estado_bar' ) ) {
     function cdb_actualizar_estado_bar() {
         if ( ! is_user_logged_in() ) {
-            wp_send_json_error( array( 'message' => 'No tienes permisos para realizar esta acción.' ) );
+            wp_send_json_error( array( 'message' => __( 'No tienes permisos para realizar esta acción.', 'cdb-form' ) ) );
         }
         if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( $_POST['security'], 'cdb_form_nonce' ) ) {
-            wp_send_json_error( array( 'message' => 'Error de seguridad.' ) );
+            wp_send_json_error( array( 'message' => __( 'Error de seguridad.', 'cdb-form' ) ) );
         }
         if ( ! isset( $_POST['bar_id'] ) || ! isset( $_POST['estado'] ) ) {
-            wp_send_json_error( array( 'message' => 'Datos inválidos.' ) );
+            wp_send_json_error( array( 'message' => __( 'Datos inválidos.', 'cdb-form' ) ) );
         }
         
         $bar_id       = intval( $_POST['bar_id'] );
@@ -118,14 +118,14 @@ if ( ! function_exists( 'cdb_actualizar_estado_bar' ) ) {
         $bar          = get_post( $bar_id );
         
         if ( ! $bar || $bar->post_author != $current_user->ID ) {
-            wp_send_json_error( array( 'message' => 'No tienes permisos para editar este bar.' ) );
+            wp_send_json_error( array( 'message' => __( 'No tienes permisos para editar este bar.', 'cdb-form' ) ) );
         }
         
         $resultado = update_post_meta( $bar_id, 'estado', $estado );
         if ( $resultado !== false ) {
-            wp_send_json_success( array( 'message' => 'Estado del bar actualizado correctamente.' ) );
+            wp_send_json_success( array( 'message' => __( 'Estado del bar actualizado correctamente.', 'cdb-form' ) ) );
         } else {
-            wp_send_json_error( array( 'message' => 'Error al actualizar el estado del bar.' ) );
+            wp_send_json_error( array( 'message' => __( 'Error al actualizar el estado del bar.', 'cdb-form' ) ) );
         }
         wp_die();
     }
@@ -140,7 +140,7 @@ add_action( 'wp_ajax_cdb_actualizar_estado_bar', 'cdb_actualizar_estado_bar' );
 if ( ! function_exists( 'cdb_obtener_anios_bar' ) ) {
     function cdb_obtener_anios_bar() {
         if ( ! isset( $_GET['bar_id'] ) ) {
-            wp_send_json_error( array( 'message' => 'Bar ID no proporcionado.' ) );
+            wp_send_json_error( array( 'message' => __( 'Bar ID no proporcionado.', 'cdb-form' ) ) );
         }
         
         $bar_id         = intval( $_GET['bar_id'] );
@@ -148,7 +148,7 @@ if ( ! function_exists( 'cdb_obtener_anios_bar' ) ) {
         $fecha_cierre   = get_post_meta( $bar_id, '_cdb_bar_cierre', true );
         
         if ( ! $fecha_apertura ) {
-            wp_send_json_error( array( 'message' => 'No se encontraron fechas para este bar.' ) );
+            wp_send_json_error( array( 'message' => __( 'No se encontraron fechas para este bar.', 'cdb-form' ) ) );
         }
         
         $fecha_apertura = intval( $fecha_apertura );
@@ -173,10 +173,10 @@ add_action( 'wp_ajax_cdb_obtener_anios_bar', 'cdb_obtener_anios_bar' );
 if ( ! function_exists( 'cdb_guardar_experiencia' ) ) {
     function cdb_guardar_experiencia() {
         if ( ! is_user_logged_in() ) {
-            wp_send_json_error( array( 'message' => 'No tienes permisos.' ) );
+            wp_send_json_error( array( 'message' => __( 'No tienes permisos.', 'cdb-form' ) ) );
         }
         if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( $_POST['security'], 'cdb_form_nonce' ) ) {
-            wp_send_json_error( array( 'message' => 'Error de seguridad.' ) );
+            wp_send_json_error( array( 'message' => __( 'Error de seguridad.', 'cdb-form' ) ) );
         }
         
         $empleado_id = intval( $_POST['empleado_id'] );
@@ -231,9 +231,9 @@ if ( ! function_exists( 'cdb_guardar_experiencia' ) ) {
             
             // Actualizar el meta "cdb_experiencia_score" del empleado.
             cdb_actualizar_experiencia_score( $empleado_id );
-            wp_send_json_success( array( 'message' => 'Experiencia guardada correctamente.', 'experiencia_total' => $experiencia_total ) );
+            wp_send_json_success( array( 'message' => __( 'Experiencia guardada correctamente.', 'cdb-form' ), 'experiencia_total' => $experiencia_total ) );
         } else {
-            wp_send_json_error( array( 'message' => 'No se pudo guardar la experiencia.' ) );
+            wp_send_json_error( array( 'message' => __( 'No se pudo guardar la experiencia.', 'cdb-form' ) ) );
         }
         wp_die();
     }
@@ -250,13 +250,13 @@ add_action( 'wp_ajax_nopriv_cdb_guardar_experiencia', 'cdb_guardar_experiencia' 
 if ( ! function_exists( 'cdb_borrar_experiencia' ) ) {
     function cdb_borrar_experiencia() {
         if ( ! is_user_logged_in() ) {
-            wp_send_json_error( array('message' => 'No tienes permisos (no logueado).') );
+            wp_send_json_error( array('message' => __( 'No tienes permisos (no logueado).', 'cdb-form' ) ) );
         }
         if ( ! isset($_POST['security']) || ! wp_verify_nonce($_POST['security'], 'cdb_form_nonce') ) {
-            wp_send_json_error( array('message' => 'Error de seguridad (nonce).') );
+            wp_send_json_error( array('message' => __( 'Error de seguridad (nonce).', 'cdb-form' ) ) );
         }
         if ( ! isset($_POST['exp_id']) ) {
-            wp_send_json_error( array('message' => 'ID de experiencia no proporcionado.') );
+            wp_send_json_error( array('message' => __( 'ID de experiencia no proporcionado.', 'cdb-form' ) ) );
         }
         $exp_id = intval($_POST['exp_id']);
         global $wpdb;
@@ -268,7 +268,7 @@ if ( ! function_exists( 'cdb_borrar_experiencia' ) ) {
             $wpdb->prepare("SELECT empleado_id FROM {$tabla_exp} WHERE id = %d", $exp_id)
         );
         if ( ! $fila || $fila->empleado_id != $empleado_id ) {
-            wp_send_json_error( array('message' => 'No tienes permiso para eliminar esa experiencia.') );
+            wp_send_json_error( array('message' => __( 'No tienes permiso para eliminar esa experiencia.', 'cdb-form' ) ) );
         }
         
         // Borrar el registro.
@@ -280,9 +280,9 @@ if ( ! function_exists( 'cdb_borrar_experiencia' ) ) {
         if ( $borrado ) {
             // Actualizar el meta "cdb_experiencia_score".
             cdb_actualizar_experiencia_score( $empleado_id );
-            wp_send_json_success( array( 'message' => 'Experiencia eliminada correctamente.' ) );
+            wp_send_json_success( array( 'message' => __( 'Experiencia eliminada correctamente.', 'cdb-form' ) ) );
         } else {
-            wp_send_json_error( array( 'message' => 'No se pudo eliminar la experiencia.' ) );
+            wp_send_json_error( array( 'message' => __( 'No se pudo eliminar la experiencia.', 'cdb-form' ) ) );
         }
         wp_die();
     }
@@ -297,7 +297,7 @@ add_action('wp_ajax_cdb_borrar_experiencia', 'cdb_borrar_experiencia');
 if ( ! function_exists( 'cdb_listar_experiencias' ) ) {
     function cdb_listar_experiencias() {
         if ( ! is_user_logged_in() ) {
-            wp_die( 'Debes iniciar sesión para ver la experiencia.', 403 );
+            wp_die( __( 'Debes iniciar sesión para ver la experiencia.', 'cdb-form' ), 403 );
         }
         global $wpdb;
         $empleado_id = isset( $_GET['empleado_id'] ) ? intval( $_GET['empleado_id'] ) : 0;
@@ -339,7 +339,7 @@ if ( ! function_exists( 'cdb_listar_experiencias' ) ) {
                         <td>
                             <!-- Botón para borrar experiencia -->
                             <button class="cdb-btn-borrar" data-exp-id="<?php echo esc_attr($exp->exp_id); ?>">
-                                Borrar
+                                <?php esc_html_e( 'Borrar', 'cdb-form' ); ?>
                             </button>
                         </td>
                     </tr>
@@ -347,7 +347,7 @@ if ( ! function_exists( 'cdb_listar_experiencias' ) ) {
                 </tbody>
             </table>
         <?php else : ?>
-            <p>No tienes experiencia registrada aún.</p>
+            <p><?php esc_html_e( 'No tienes experiencia registrada aún.', 'cdb-form' ); ?></p>
         <?php
         endif;
         $html = ob_get_clean();

--- a/includes/form-handler.php
+++ b/includes/form-handler.php
@@ -27,20 +27,20 @@ if (!function_exists('cdb_actualizar_experiencia_score')) {
 function cdb_guardar_experiencia() {
     // 1. Verificar nonce para seguridad.
     if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'cdb_form_nonce')) {
-        wp_send_json_error(['message' => 'Error de seguridad.']);
+        wp_send_json_error(['message' => __('Error de seguridad.', 'cdb-form')]);
         wp_die();
     }
 
     // 2. Obtener el usuario actual.
     $current_user = wp_get_current_user();
     if (!$current_user->exists()) {
-        wp_send_json_error(['message' => 'Debes iniciar sesión para completar este formulario.']);
+        wp_send_json_error(['message' => __('Debes iniciar sesión para completar este formulario.', 'cdb-form')]);
         wp_die();
     }
 
     // 3. Validar que los campos obligatorios se hayan enviado.
     if (!isset($_POST['bar_id'], $_POST['posicion_id'], $_POST['anio'])) {
-        wp_send_json_error(['message' => 'Todos los campos son obligatorios.']);
+        wp_send_json_error(['message' => __('Todos los campos son obligatorios.', 'cdb-form')]);
         wp_die();
     }
 
@@ -55,7 +55,7 @@ function cdb_guardar_experiencia() {
     // 5. Verificar que el usuario está editando su propio perfil.
     $post = get_post($empleado_id);
     if (!$post || $post->post_author != $current_user->ID) {
-        wp_send_json_error(['message' => 'No tienes permisos para editar este perfil.']);
+        wp_send_json_error(['message' => __('No tienes permisos para editar este perfil.', 'cdb-form')]);
         wp_die();
     }
 
@@ -78,7 +78,7 @@ function cdb_guardar_experiencia() {
     // 7. Verificar si ocurrió algún error durante la inserción.
     if ($wpdb->last_error) {
         error_log("[ERROR] Fallo al insertar experiencia: " . $wpdb->last_error);
-        wp_send_json_error(['message' => 'Error al registrar la experiencia.']);
+        wp_send_json_error(['message' => __('Error al registrar la experiencia.', 'cdb-form')]);
         wp_die();
     }
 
@@ -113,11 +113,11 @@ function cdb_guardar_experiencia() {
 
         // 10. Enviar respuesta JSON indicando éxito y solicitando la recarga de la página.
         wp_send_json_success([
-            'message' => 'Experiencia registrada correctamente.',
+            'message' => __( 'Experiencia registrada correctamente.', 'cdb-form' ),
             'reload'  => true // Instrucción para que el JS recargue la página.
         ]);
     } else {
-        wp_send_json_error(['message' => 'No se pudo guardar la experiencia.']);
+        wp_send_json_error(['message' => __( 'No se pudo guardar la experiencia.', 'cdb-form' )]);
     }
 
     wp_die();
@@ -137,7 +137,7 @@ function cdb_form_empleado_submit() {
 
     $current_user = wp_get_current_user();
     if (!$current_user->exists()) {
-        wp_send_json_error(['message' => 'Debes iniciar sesión para completar este formulario.']);
+        wp_send_json_error(['message' => __('Debes iniciar sesión para completar este formulario.', 'cdb-form')]);
         wp_die();
     }
 
@@ -151,7 +151,7 @@ function cdb_form_empleado_submit() {
 
     // Validar campo obligatorio.
     if (empty($nombre)) {
-        wp_send_json_error(['message' => 'El nombre es obligatorio.']);
+        wp_send_json_error(['message' => __('El nombre es obligatorio.', 'cdb-form')]);
         wp_die();
     }
 
@@ -165,7 +165,7 @@ function cdb_form_empleado_submit() {
             'posts_per_page' => 1
         ]);
         if (!empty($existing_empleado)) {
-            wp_send_json_error(['message' => 'Ya tienes un perfil de empleado. No puedes crear más de uno.']);
+            wp_send_json_error(['message' => __('Ya tienes un perfil de empleado. No puedes crear más de uno.', 'cdb-form')]);
             wp_die();
         }
 
@@ -196,21 +196,21 @@ function cdb_form_empleado_submit() {
             update_post_meta($empleado_id, 'anio', $anio);
 
             error_log("DEBUG: Perfil de empleado creado correctamente con ID: $empleado_id");
-            wp_send_json_success(['message' => 'Perfil de empleado creado correctamente.', 'empleado_id' => $empleado_id]);
+            wp_send_json_success(['message' => __('Perfil de empleado creado correctamente.', 'cdb-form'), 'empleado_id' => $empleado_id]);
         } else {
             error_log("ERROR: No se pudo crear el perfil de empleado.");
-            wp_send_json_error(['message' => 'Error al crear el perfil.']);
+            wp_send_json_error(['message' => __('Error al crear el perfil.', 'cdb-form')]);
         }
     }
     // ACTUALIZAR PERFIL DE EMPLEADO EXISTENTE.
     else {
         $empleado_post = get_post($empleado_id);
         if (!$empleado_post || $empleado_post->post_type !== 'empleado') {
-            wp_send_json_error(['message' => 'Empleado no válido.']);
+            wp_send_json_error(['message' => __('Empleado no válido.', 'cdb-form')]);
             wp_die();
         }
         if ($empleado_post->post_author != $current_user->ID) {
-            wp_send_json_error(['message' => 'No tienes permisos para editar este empleado.']);
+            wp_send_json_error(['message' => __('No tienes permisos para editar este empleado.', 'cdb-form')]);
             wp_die();
         }
 
@@ -218,7 +218,7 @@ function cdb_form_empleado_submit() {
         update_post_meta($empleado_id, 'disponible', $disponible);
 
         error_log("DEBUG: Perfil de empleado actualizado correctamente con ID: $empleado_id");
-        wp_send_json_success(['message' => 'Perfil de empleado actualizado correctamente.']);
+        wp_send_json_success(['message' => __('Perfil de empleado actualizado correctamente.', 'cdb-form')]);
     }
 }
 

--- a/includes/init.php
+++ b/includes/init.php
@@ -40,12 +40,12 @@ function cdb_mostrar_disponibilidad_empleado($content) {
 
         // Si el valor es vacío o no está definido, mostrar "No Disponible"
         if ($disponible === "" || $disponible === null) {
-            $disponible_texto = 'No Disponible';
+            $disponible_texto = __( 'No Disponible', 'cdb-form' );
         } else {
-            $disponible_texto = ($disponible == 1) ? 'Disponible' : 'No Disponible';
+            $disponible_texto = ($disponible == 1) ? __( 'Disponible', 'cdb-form' ) : __( 'No Disponible', 'cdb-form' );
         }
 
-        $info_disponibilidad = "<p><strong>Estado:</strong> $disponible_texto</p>";
+        $info_disponibilidad = '<p><strong>' . esc_html__( 'Estado:', 'cdb-form' ) . '</strong> ' . $disponible_texto . '</p>';
 
         return $info_disponibilidad . $content;
     }

--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -19,19 +19,19 @@ if (!defined('ABSPATH')) {
  */
 function cdb_register_cpt_posiciones() {
     $labels = array(
-        'name'               => 'Posiciones',
-        'singular_name'      => 'Posición',
-        'menu_name'          => 'Posiciones',
-        'name_admin_bar'     => 'Posición',
-        'add_new'            => 'Añadir Nueva',
-        'add_new_item'       => 'Añadir Nueva Posición',
-        'new_item'           => 'Nueva Posición',
-        'edit_item'          => 'Editar Posición',
-        'view_item'          => 'Ver Posición',
-        'all_items'          => 'Todas las Posiciones',
-        'search_items'       => 'Buscar Posiciones',
-        'not_found'          => 'No se encontraron posiciones',
-        'not_found_in_trash' => 'No se encontraron posiciones en la papelera'
+        'name'               => __( 'Posiciones', 'cdb-form' ),
+        'singular_name'      => __( 'Posición', 'cdb-form' ),
+        'menu_name'          => __( 'Posiciones', 'cdb-form' ),
+        'name_admin_bar'     => __( 'Posición', 'cdb-form' ),
+        'add_new'            => __( 'Añadir Nueva', 'cdb-form' ),
+        'add_new_item'       => __( 'Añadir Nueva Posición', 'cdb-form' ),
+        'new_item'           => __( 'Nueva Posición', 'cdb-form' ),
+        'edit_item'          => __( 'Editar Posición', 'cdb-form' ),
+        'view_item'          => __( 'Ver Posición', 'cdb-form' ),
+        'all_items'          => __( 'Todas las Posiciones', 'cdb-form' ),
+        'search_items'       => __( 'Buscar Posiciones', 'cdb-form' ),
+        'not_found'          => __( 'No se encontraron posiciones', 'cdb-form' ),
+        'not_found_in_trash' => __( 'No se encontraron posiciones en la papelera', 'cdb-form' ),
     );
 
     $args = array(
@@ -64,7 +64,7 @@ add_action('init', 'cdb_register_cpt_posiciones');
 function cdb_add_meta_box_posicion_score() {
     add_meta_box(
         'cdb_posiciones_score',                 // ID del meta box.
-        'Valor de Puntuación',                  // Título que se muestra.
+        __( 'Valor de Puntuación', 'cdb-form' ), // Título que se muestra.
         'cdb_render_posiciones_score_meta_box', // Función que renderiza el contenido.
         'cdb_posiciones',                       // CPT donde se agrega.
         'side',                                 // Ubicación (side, normal, advanced).
@@ -87,7 +87,7 @@ function cdb_render_posiciones_score_meta_box($post) {
     // Obtener el valor actual de la puntuación (si existe).
     $score_value = get_post_meta($post->ID, '_cdb_posiciones_score', true);
     ?>
-    <label for="cdb_posiciones_score_field">Valor de Puntuación:</label>
+    <label for="cdb_posiciones_score_field"><?php esc_html_e( 'Valor de Puntuación:', 'cdb-form' ); ?></label>
     <input 
         type="number" 
         id="cdb_posiciones_score_field" 
@@ -141,7 +141,7 @@ add_action('save_post_cdb_posiciones', 'cdb_save_posiciones_score_meta_box');
  * Agrega una columna personalizada para mostrar la puntuación en la lista de posiciones.
  */
 function cdb_add_posiciones_custom_column($columns) {
-    $columns['cdb_posiciones_score'] = 'Puntuación';
+    $columns['cdb_posiciones_score'] = __( 'Puntuación', 'cdb-form' );
     return $columns;
 }
 add_filter('manage_cdb_posiciones_posts_columns', 'cdb_add_posiciones_custom_column');

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -87,11 +87,11 @@ function cdb_calcular_puntuacion_experiencia_dinamica($empleado_id) {
  */
 function cdb_bienvenida_usuario_shortcode() {
     if (!is_user_logged_in()) {
-        return '<p style="color: red;">Debes iniciar sesión para acceder a esta página.</p>';
+        return '<p style="color: red;">' . esc_html__( 'Debes iniciar sesión para acceder a esta página.', 'cdb-form' ) . '</p>';
     }
     $current_user = wp_get_current_user();
-    $output  = '<h1>¡Hola, ' . esc_html($current_user->display_name) . '!</h1>';
-    $output .= '<p>Grácias por colaborar con el Proyecto CdB!</p>';
+    $output  = '<h1>' . sprintf( esc_html__( '¡Hola, %s!', 'cdb-form' ), esc_html($current_user->display_name) ) . '</h1>';
+    $output .= '<p>' . esc_html__( 'Grácias por colaborar con el Proyecto CdB!', 'cdb-form' ) . '</p>';
 
     // Cargar la sección de empleado si el usuario tiene ese rol.
     if (in_array('empleado', (array) $current_user->roles)) {
@@ -133,18 +133,18 @@ function cdb_bienvenida_empleado_shortcode() {
         $empleado_url     = get_permalink($empleado_id);
         $disponible       = get_post_meta($empleado_id, 'disponible', true);
 
-        $output .= '<p><strong>Tu empleado:</strong> <a href="' . esc_url($empleado_url) . '">' . esc_html($empleado_nombre) . '</a></p>';
+        $output .= '<p><strong>' . esc_html__( 'Tu empleado:', 'cdb-form' ) . '</strong> <a href="' . esc_url($empleado_url) . '">' . esc_html($empleado_nombre) . '</a></p>';
 
         // Formulario para actualizar disponibilidad.
         $output .= '<form id="cdb-update-disponibilidad" method="post">
-                        <label for="disponible">Actualizar Disponibilidad:</label>
+                        <label for="disponible">' . esc_html__( 'Actualizar Disponibilidad:', 'cdb-form' ) . '</label>
                         <select id="disponible" name="disponible">
-                            <option value="1" ' . selected($disponible, 1, false) . '>Sí</option>
-                            <option value="0" ' . selected($disponible, 0, false) . '>No</option>
+                            <option value="1" ' . selected($disponible, 1, false) . '>' . esc_html__( 'Sí', 'cdb-form' ) . '</option>
+                            <option value="0" ' . selected($disponible, 0, false) . '>' . esc_html__( 'No', 'cdb-form' ) . '</option>
                         </select>
                         <input type="hidden" name="empleado_id" value="' . esc_attr($empleado_id) . '">
                         <input type="hidden" name="security" value="' . wp_create_nonce('cdb_form_nonce') . '">
-                        <button type="submit">Actualizar</button>
+                        <button type="submit">' . esc_html__( 'Actualizar', 'cdb-form' ) . '</button>
                     </form>';
 
         // Obtener la puntuación gráfica y la de experiencia
@@ -158,13 +158,13 @@ function cdb_bienvenida_empleado_shortcode() {
             $puntuacion_total_final = round($puntuacion_total_final, 1); // Redondeamos a 1 decimal (opcional)
             $output .= cdb_generar_barra_progreso_simple($puntuacion_total_final);
         } else {
-            $output .= '<p>Puntuación Gráfica no disponible.</p>';
+            $output .= '<p>' . esc_html__( 'Puntuación Gráfica no disponible.', 'cdb-form' ) . '</p>';
         }
 
         // Mostrar la Puntuación de Experiencia.
-        $output .= '<p><strong>Puntuación de Experiencia:</strong> ' . esc_html($puntuacion_experiencia) . '</p>';
+        $output .= '<p><strong>' . esc_html__( 'Puntuación de Experiencia:', 'cdb-form' ) . '</strong> ' . esc_html($puntuacion_experiencia) . '</p>';
     } else {
-        $output .= '<p style="color: red;">No tienes ningún perfil de empleado asignado.</p>';
+        $output .= '<p style="color: red;">' . esc_html__( 'No tienes ningún perfil de empleado asignado.', 'cdb-form' ) . '</p>';
         $output .= do_shortcode('[cdb_form_empleado]');
     }
     return $output;
@@ -263,7 +263,7 @@ function cdb_generar_barra_progreso_simple($puntuacion_total) {
  */
 function cdb_experiencia_shortcode() {
     if (!is_user_logged_in()) {
-        return '<p style="color: red;">Debes iniciar sesión para acceder a esta página.</p>';
+        return '<p style="color: red;">' . esc_html__( 'Debes iniciar sesión para acceder a esta página.', 'cdb-form' ) . '</p>';
     }
     $current_user = wp_get_current_user();
     if (!in_array('empleado', (array) $current_user->roles)) {
@@ -271,7 +271,7 @@ function cdb_experiencia_shortcode() {
     }
     $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
     if ($empleado_id === 0) {
-        return '<p style="color: red;">No tienes un perfil de empleado registrado.</p>';
+        return '<p style="color: red;">' . esc_html__( 'No tienes un perfil de empleado registrado.', 'cdb-form' ) . '</p>';
     }
     ob_start();
     include CDB_FORM_PATH . 'templates/form-experiencia-template.php';
@@ -325,7 +325,7 @@ add_shortcode('cdb_form_bar', 'cdb_form_bar_shortcode');
  */
 function cdb_mostrar_puntuacion_total() {
     if (!is_user_logged_in()) {
-        return '<p>Error: Debes iniciar sesión para ver tu puntuación.</p>';
+        return '<p>' . esc_html__( 'Error: Debes iniciar sesión para ver tu puntuación.', 'cdb-form' ) . '</p>';
     }
     $current_user = wp_get_current_user();
     if (!in_array('empleado', (array) $current_user->roles)) {
@@ -333,13 +333,13 @@ function cdb_mostrar_puntuacion_total() {
     }
     $empleado_id = cdb_obtener_empleado_id($current_user->ID);
     if (!$empleado_id) {
-        return '<p>No se encontró un empleado asociado a este usuario.</p>';
+        return '<p>' . esc_html__( 'No se encontró un empleado asociado a este usuario.', 'cdb-form' ) . '</p>';
     }
     $puntuacion_total = get_post_meta($empleado_id, 'cdb_puntuacion_total', true);
     if (!$puntuacion_total) {
-        return '<p>Puntuación Gráfica no disponible.</p>';
+        return '<p>' . esc_html__( 'Puntuación Gráfica no disponible.', 'cdb-form' ) . '</p>';
     }
-    return '<p><strong>Puntuación Gráfica:</strong> ' . esc_html($puntuacion_total) . '</p>';
+    return '<p><strong>' . esc_html__( 'Puntuación Gráfica:', 'cdb-form' ) . '</strong> ' . esc_html($puntuacion_total) . '</p>';
 }
 add_shortcode('cdb_puntuacion_total', 'cdb_mostrar_puntuacion_total');
 
@@ -386,7 +386,7 @@ function cdb_top_empleados_experiencia_precalculada_shortcode() {
 
     // 5) Si no hay empleados, avisar
     if (!$query->have_posts()) {
-        return '<p>No se encontraron empleados.</p>';
+        return '<p>' . esc_html__( 'No se encontraron empleados.', 'cdb-form' ) . '</p>';
     }
 
     // 6) Generar la tabla
@@ -486,7 +486,7 @@ function cdb_top_empleados_puntuacion_total_shortcode() {
 
     // 5) Si no hay empleados, salimos.
     if (!$query->have_posts()) {
-        return '<p>No se encontraron empleados con puntuación total.</p>';
+        return '<p>' . esc_html__( 'No se encontraron empleados con puntuación total.', 'cdb-form' ) . '</p>';
     }
 
     // 6) Cabecera de la tabla

--- a/languages/cdb-form.pot
+++ b/languages/cdb-form.pot
@@ -1,0 +1,388 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-01 10:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: templates/form-experiencia-template.php:10
+#: templates/form-empleado-template.php:10
+msgid "Debes iniciar sesión para gestionar tu empleado."
+msgstr ""
+
+#: templates/form-experiencia-template.php:17
+msgid ""
+"No tienes un perfil de empleado registrado. Para registrar experiencia, "
+"primero debes crear tu perfil de empleado."
+msgstr ""
+
+#: templates/form-experiencia-template.php:193 includes/ajax-functions.php:350
+msgid "No tienes experiencia registrada aún."
+msgstr ""
+
+#: templates/form-experiencia-template.php:199
+msgid "Actualizar Experiencia Laboral"
+msgstr ""
+
+#: templates/form-empleado-template.php:26
+msgid "Actualizar Empleado"
+msgstr ""
+
+#: templates/form-empleado-template.php:31
+msgid "Crear Empleado"
+msgstr ""
+
+#: templates/form-empleado-template.php:42
+msgid "Nombre:"
+msgstr ""
+
+#: templates/form-empleado-template.php:45
+msgid "Disponible:"
+msgstr ""
+
+#: templates/form-empleado-template.php:47 public/form-empleado.php:58
+#: includes/shortcodes.php:142
+msgid "Sí"
+msgstr ""
+
+#: templates/form-empleado-template.php:48 public/form-empleado.php:59
+#: includes/shortcodes.php:143
+msgid "No"
+msgstr ""
+
+#: templates/form-bar-template.php:29
+msgid "Nombre del Bar:"
+msgstr ""
+
+#: templates/form-bar-template.php:32 includes/init.php:48
+msgid "Estado:"
+msgstr ""
+
+#: templates/form-bar-template.php:34 public/form-bar.php:41
+msgid "Abierto todo el año"
+msgstr ""
+
+#: templates/form-bar-template.php:35 public/form-bar.php:42
+msgid "Abierto temporalmente"
+msgstr ""
+
+#: templates/form-bar-template.php:36 public/form-bar.php:43
+msgid "Cerrado temporalmente"
+msgstr ""
+
+#: templates/form-bar-template.php:37 public/form-bar.php:44
+msgid "Cerrado permanente"
+msgstr ""
+
+#: templates/form-bar-template.php:38 public/form-bar.php:45
+msgid "Traspaso"
+msgstr ""
+
+#: templates/form-bar-template.php:39 public/form-bar.php:46
+msgid "Desconocido"
+msgstr ""
+
+#: templates/form-bar-template.php:42 public/form-bar.php:50
+#: public/form-empleado.php:63 includes/shortcodes.php:147
+msgid "Actualizar"
+msgstr ""
+
+#: public/form-bar.php:15
+msgid "Debes iniciar sesión para actualizar el estado de tu bar."
+msgstr ""
+
+#: public/form-bar.php:29
+msgid "No tienes un bar registrado. Crea uno antes de actualizar su estado."
+msgstr ""
+
+#: public/form-bar.php:39
+msgid "Estado del Bar:"
+msgstr ""
+
+#: public/form-empleado.php:27
+msgid "Debes iniciar sesión para actualizar tu estado."
+msgstr ""
+
+#: public/form-empleado.php:32
+msgid "No tienes permisos para acceder a esta sección."
+msgstr ""
+
+#: public/form-empleado.php:46
+msgid ""
+"No tienes un perfil de empleado. Crea uno antes de actualizar tu "
+"disponibilidad."
+msgstr ""
+
+#: public/form-empleado.php:56
+msgid "¿Estás disponible?"
+msgstr ""
+
+#: test.php:5
+msgid "Debes iniciar sesión."
+msgstr ""
+
+#: includes/post-types.php:22 includes/post-types.php:24
+msgid "Posiciones"
+msgstr ""
+
+#: includes/post-types.php:23 includes/post-types.php:25
+msgid "Posición"
+msgstr ""
+
+#: includes/post-types.php:26
+msgid "Añadir Nueva"
+msgstr ""
+
+#: includes/post-types.php:27
+msgid "Añadir Nueva Posición"
+msgstr ""
+
+#: includes/post-types.php:28
+msgid "Nueva Posición"
+msgstr ""
+
+#: includes/post-types.php:29
+msgid "Editar Posición"
+msgstr ""
+
+#: includes/post-types.php:30
+msgid "Ver Posición"
+msgstr ""
+
+#: includes/post-types.php:31
+msgid "Todas las Posiciones"
+msgstr ""
+
+#: includes/post-types.php:32
+msgid "Buscar Posiciones"
+msgstr ""
+
+#: includes/post-types.php:33
+msgid "No se encontraron posiciones"
+msgstr ""
+
+#: includes/post-types.php:34
+msgid "No se encontraron posiciones en la papelera"
+msgstr ""
+
+#: includes/post-types.php:67
+msgid "Valor de Puntuación"
+msgstr ""
+
+#: includes/post-types.php:90
+msgid "Valor de Puntuación:"
+msgstr ""
+
+#: includes/post-types.php:144
+msgid "Puntuación"
+msgstr ""
+
+#: includes/shortcodes.php:90 includes/shortcodes.php:266
+msgid "Debes iniciar sesión para acceder a esta página."
+msgstr ""
+
+#: includes/shortcodes.php:93
+#, php-format
+msgid "¡Hola, %s!"
+msgstr ""
+
+#: includes/shortcodes.php:94
+msgid "Grácias por colaborar con el Proyecto CdB!"
+msgstr ""
+
+#: includes/shortcodes.php:136
+msgid "Tu empleado:"
+msgstr ""
+
+#: includes/shortcodes.php:140
+msgid "Actualizar Disponibilidad:"
+msgstr ""
+
+#: includes/shortcodes.php:161 includes/shortcodes.php:340
+msgid "Puntuación Gráfica no disponible."
+msgstr ""
+
+#: includes/shortcodes.php:165
+msgid "Puntuación de Experiencia:"
+msgstr ""
+
+#: includes/shortcodes.php:167
+msgid "No tienes ningún perfil de empleado asignado."
+msgstr ""
+
+#: includes/shortcodes.php:274
+msgid "No tienes un perfil de empleado registrado."
+msgstr ""
+
+#: includes/shortcodes.php:328
+msgid "Error: Debes iniciar sesión para ver tu puntuación."
+msgstr ""
+
+#: includes/shortcodes.php:336
+msgid "No se encontró un empleado asociado a este usuario."
+msgstr ""
+
+#: includes/shortcodes.php:342
+msgid "Puntuación Gráfica:"
+msgstr ""
+
+#: includes/shortcodes.php:389
+msgid "No se encontraron empleados."
+msgstr ""
+
+#: includes/shortcodes.php:489
+msgid "No se encontraron empleados con puntuación total."
+msgstr ""
+
+#: includes/form-handler.php:30 includes/ajax-functions.php:72
+#: includes/ajax-functions.php:109 includes/ajax-functions.php:179
+msgid "Error de seguridad."
+msgstr ""
+
+#: includes/form-handler.php:37 includes/form-handler.php:140
+msgid "Debes iniciar sesión para completar este formulario."
+msgstr ""
+
+#: includes/form-handler.php:43
+msgid "Todos los campos son obligatorios."
+msgstr ""
+
+#: includes/form-handler.php:58
+msgid "No tienes permisos para editar este perfil."
+msgstr ""
+
+#: includes/form-handler.php:81
+msgid "Error al registrar la experiencia."
+msgstr ""
+
+#: includes/form-handler.php:116
+msgid "Experiencia registrada correctamente."
+msgstr ""
+
+#: includes/form-handler.php:120 includes/ajax-functions.php:236
+msgid "No se pudo guardar la experiencia."
+msgstr ""
+
+#: includes/form-handler.php:154
+msgid "El nombre es obligatorio."
+msgstr ""
+
+#: includes/form-handler.php:168
+msgid "Ya tienes un perfil de empleado. No puedes crear más de uno."
+msgstr ""
+
+#: includes/form-handler.php:199
+msgid "Perfil de empleado creado correctamente."
+msgstr ""
+
+#: includes/form-handler.php:202
+msgid "Error al crear el perfil."
+msgstr ""
+
+#: includes/form-handler.php:209
+msgid "Empleado no válido."
+msgstr ""
+
+#: includes/form-handler.php:213 includes/ajax-functions.php:84
+msgid "No tienes permisos para editar este empleado."
+msgstr ""
+
+#: includes/form-handler.php:221
+msgid "Perfil de empleado actualizado correctamente."
+msgstr ""
+
+#: includes/ajax-functions.php:69 includes/ajax-functions.php:106
+msgid "No tienes permisos para realizar esta acción."
+msgstr ""
+
+#: includes/ajax-functions.php:75 includes/ajax-functions.php:112
+msgid "Datos inválidos."
+msgstr ""
+
+#: includes/ajax-functions.php:89
+msgid "Disponibilidad actualizada correctamente."
+msgstr ""
+
+#: includes/ajax-functions.php:91
+msgid "Error al actualizar la disponibilidad."
+msgstr ""
+
+#: includes/ajax-functions.php:121
+msgid "No tienes permisos para editar este bar."
+msgstr ""
+
+#: includes/ajax-functions.php:126
+msgid "Estado del bar actualizado correctamente."
+msgstr ""
+
+#: includes/ajax-functions.php:128
+msgid "Error al actualizar el estado del bar."
+msgstr ""
+
+#: includes/ajax-functions.php:143
+msgid "Bar ID no proporcionado."
+msgstr ""
+
+#: includes/ajax-functions.php:151
+msgid "No se encontraron fechas para este bar."
+msgstr ""
+
+#: includes/ajax-functions.php:176
+msgid "No tienes permisos."
+msgstr ""
+
+#: includes/ajax-functions.php:234
+msgid "Experiencia guardada correctamente."
+msgstr ""
+
+#: includes/ajax-functions.php:253
+msgid "No tienes permisos (no logueado)."
+msgstr ""
+
+#: includes/ajax-functions.php:256
+msgid "Error de seguridad (nonce)."
+msgstr ""
+
+#: includes/ajax-functions.php:259
+msgid "ID de experiencia no proporcionado."
+msgstr ""
+
+#: includes/ajax-functions.php:271
+msgid "No tienes permiso para eliminar esa experiencia."
+msgstr ""
+
+#: includes/ajax-functions.php:283
+msgid "Experiencia eliminada correctamente."
+msgstr ""
+
+#: includes/ajax-functions.php:285
+msgid "No se pudo eliminar la experiencia."
+msgstr ""
+
+#: includes/ajax-functions.php:300
+msgid "Debes iniciar sesión para ver la experiencia."
+msgstr ""
+
+#: includes/ajax-functions.php:342
+msgid "Borrar"
+msgstr ""
+
+#: includes/init.php:43 includes/init.php:45
+msgid "No Disponible"
+msgstr ""
+
+#: includes/init.php:45
+msgid "Disponible"
+msgstr ""

--- a/public/form-bar.php
+++ b/public/form-bar.php
@@ -12,7 +12,7 @@ add_shortcode( 'form-bar', 'cdb_form_bar' );
 function cdb_form_bar() {
     // Comprobar si el usuario está conectado.
     if ( ! is_user_logged_in() ) {
-        return '<p>Debes iniciar sesión para actualizar el estado de tu bar.</p>';
+        return '<p>' . esc_html__( 'Debes iniciar sesión para actualizar el estado de tu bar.', 'cdb-form' ) . '</p>';
     }
 
     // Obtener el ID del usuario actual.
@@ -26,7 +26,7 @@ function cdb_form_bar() {
     ));
 
     if (empty($bar)) {
-        return '<p>No tienes un bar registrado. Crea uno antes de actualizar su estado.</p>';
+        return '<p>' . esc_html__( 'No tienes un bar registrado. Crea uno antes de actualizar su estado.', 'cdb-form' ) . '</p>';
     }
 
     $bar_id = $bar[0]->ID;
@@ -36,18 +36,18 @@ function cdb_form_bar() {
     ob_start();
     ?>
     <form id="cdb-update-estado-bar" method="post">
-        <label for="estado">Estado del Bar:</label>
+        <label for="estado"><?php esc_html_e( 'Estado del Bar:', 'cdb-form' ); ?></label>
         <select name="estado" id="estado">
-            <option value="Abierto todo el año" <?php selected($estado_actual, 'Abierto todo el año'); ?>>Abierto todo el año</option>
-            <option value="Abierto temporalmente" <?php selected($estado_actual, 'Abierto temporalmente'); ?>>Abierto temporalmente</option>
-            <option value="Cerrado temporalmente" <?php selected($estado_actual, 'Cerrado temporalmente'); ?>>Cerrado temporalmente</option>
-            <option value="Cerrado permanente" <?php selected($estado_actual, 'Cerrado permanente'); ?>>Cerrado permanente</option>
-            <option value="Traspaso" <?php selected($estado_actual, 'Traspaso'); ?>>Traspaso</option>
-            <option value="Desconocido" <?php selected($estado_actual, 'Desconocido'); ?>>Desconocido</option>
+            <option value="Abierto todo el año" <?php selected($estado_actual, 'Abierto todo el año'); ?>><?php esc_html_e( 'Abierto todo el año', 'cdb-form' ); ?></option>
+            <option value="Abierto temporalmente" <?php selected($estado_actual, 'Abierto temporalmente'); ?>><?php esc_html_e( 'Abierto temporalmente', 'cdb-form' ); ?></option>
+            <option value="Cerrado temporalmente" <?php selected($estado_actual, 'Cerrado temporalmente'); ?>><?php esc_html_e( 'Cerrado temporalmente', 'cdb-form' ); ?></option>
+            <option value="Cerrado permanente" <?php selected($estado_actual, 'Cerrado permanente'); ?>><?php esc_html_e( 'Cerrado permanente', 'cdb-form' ); ?></option>
+            <option value="Traspaso" <?php selected($estado_actual, 'Traspaso'); ?>><?php esc_html_e( 'Traspaso', 'cdb-form' ); ?></option>
+            <option value="Desconocido" <?php selected($estado_actual, 'Desconocido'); ?>><?php esc_html_e( 'Desconocido', 'cdb-form' ); ?></option>
         </select>
         <input type="hidden" name="bar_id" value="<?php echo esc_attr($bar_id); ?>">
         <input type="hidden" name="security" value="<?php echo wp_create_nonce('cdb_form_nonce'); ?>">
-        <button type="submit">Actualizar</button>
+        <button type="submit"><?php esc_html_e( 'Actualizar', 'cdb-form' ); ?></button>
     </form>
     <p id="cdb-response-message-bar" style="color: green;"></p>
     <?php

--- a/public/form-empleado.php
+++ b/public/form-empleado.php
@@ -24,12 +24,12 @@ function cdb_usuario_es_empleado() {
 function cdb_form_empleado() {
     // Comprobar si el usuario está conectado.
     if ( ! is_user_logged_in() ) {
-        return '<p style="color: red;">Debes iniciar sesión para actualizar tu estado.</p>';
+        return '<p style="color: red;">' . esc_html__( 'Debes iniciar sesión para actualizar tu estado.', 'cdb-form' ) . '</p>';
     }
 
     // Comprobar si el usuario tiene el rol "Empleado".
     if ( ! cdb_usuario_es_empleado() ) {
-        return '<p style="color: red;">No tienes permisos para acceder a esta sección.</p>';
+        return '<p style="color: red;">' . esc_html__( 'No tienes permisos para acceder a esta sección.', 'cdb-form' ) . '</p>';
     }
 
     // Obtener el ID del usuario actual.
@@ -43,7 +43,7 @@ function cdb_form_empleado() {
     ]);
 
     if (empty($empleado)) {
-        return '<p style="color: red;">No tienes un perfil de empleado. Crea uno antes de actualizar tu disponibilidad.</p>';
+        return '<p style="color: red;">' . esc_html__( 'No tienes un perfil de empleado. Crea uno antes de actualizar tu disponibilidad.', 'cdb-form' ) . '</p>';
     }
 
     $empleado_id = $empleado[0]->ID;
@@ -53,14 +53,14 @@ function cdb_form_empleado() {
     ob_start();
     ?>
     <form id="cdb-update-disponibilidad" method="post">
-        <label for="disponible"><strong>¿Estás disponible?</strong></label>
+        <label for="disponible"><strong><?php esc_html_e( '¿Estás disponible?', 'cdb-form' ); ?></strong></label>
         <select name="disponible" id="disponible">
-            <option value="1" <?php selected($disponible, 1); ?>>Sí</option>
-            <option value="0" <?php selected($disponible, 0); ?>>No</option>
+            <option value="1" <?php selected($disponible, 1); ?>><?php esc_html_e( 'Sí', 'cdb-form' ); ?></option>
+            <option value="0" <?php selected($disponible, 0); ?>><?php esc_html_e( 'No', 'cdb-form' ); ?></option>
         </select>
         <input type="hidden" name="empleado_id" value="<?php echo esc_attr($empleado_id); ?>">
         <input type="hidden" name="security" value="<?php echo wp_create_nonce('cdb_form_nonce'); ?>">
-        <button type="submit">Actualizar</button>
+        <button type="submit"><?php esc_html_e( 'Actualizar', 'cdb-form' ); ?></button>
     </form>
     <p id="cdb-response-message" style="color: green;"></p>
 

--- a/templates/form-bar-template.php
+++ b/templates/form-bar-template.php
@@ -26,20 +26,20 @@ if (!empty($existing_bar)) {
     <?php wp_nonce_field( 'cdb_form_nonce', 'security' ); ?>
     <input type="hidden" name="bar_id" value="<?php echo esc_attr($bar_id); ?>">
 
-    <label for="nombre_bar">Nombre del Bar:</label>
+    <label for="nombre_bar"><?php esc_html_e( 'Nombre del Bar:', 'cdb-form' ); ?></label>
     <input type="text" id="nombre_bar" name="nombre_bar" value="<?php echo esc_attr($bar_nombre); ?>" required>
 
-    <label for="estado">Estado:</label>
+    <label for="estado"><?php esc_html_e( 'Estado:', 'cdb-form' ); ?></label>
     <select id="estado" name="estado">
-        <option value="Abierto todo el año" <?php selected($bar_estado, 'Abierto todo el año'); ?>>Abierto todo el año</option>
-        <option value="Abierto temporalmente" <?php selected($bar_estado, 'Abierto temporalmente'); ?>>Abierto temporalmente</option>
-        <option value="Cerrado temporalmente" <?php selected($bar_estado, 'Cerrado temporalmente'); ?>>Cerrado temporalmente</option>
-        <option value="Cerrado permanente" <?php selected($bar_estado, 'Cerrado permanente'); ?>>Cerrado permanente</option>
-        <option value="Traspaso" <?php selected($bar_estado, 'Traspaso'); ?>>Traspaso</option>
-        <option value="Desconocido" <?php selected($bar_estado, 'Desconocido'); ?>>Desconocido</option>
+        <option value="Abierto todo el año" <?php selected($bar_estado, 'Abierto todo el año'); ?>><?php esc_html_e( 'Abierto todo el año', 'cdb-form' ); ?></option>
+        <option value="Abierto temporalmente" <?php selected($bar_estado, 'Abierto temporalmente'); ?>><?php esc_html_e( 'Abierto temporalmente', 'cdb-form' ); ?></option>
+        <option value="Cerrado temporalmente" <?php selected($bar_estado, 'Cerrado temporalmente'); ?>><?php esc_html_e( 'Cerrado temporalmente', 'cdb-form' ); ?></option>
+        <option value="Cerrado permanente" <?php selected($bar_estado, 'Cerrado permanente'); ?>><?php esc_html_e( 'Cerrado permanente', 'cdb-form' ); ?></option>
+        <option value="Traspaso" <?php selected($bar_estado, 'Traspaso'); ?>><?php esc_html_e( 'Traspaso', 'cdb-form' ); ?></option>
+        <option value="Desconocido" <?php selected($bar_estado, 'Desconocido'); ?>><?php esc_html_e( 'Desconocido', 'cdb-form' ); ?></option>
     </select>
 
-    <button type="submit">Actualizar</button>
+    <button type="submit"><?php esc_html_e( 'Actualizar', 'cdb-form' ); ?></button>
 </form>
 
 <script>

--- a/templates/form-empleado-template.php
+++ b/templates/form-empleado-template.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) {
 // Verificar si el usuario está conectado
 $current_user = wp_get_current_user();
 if (!$current_user->exists()) {
-    echo '<p>Debes iniciar sesión para gestionar tu empleado.</p>';
+    echo '<p>' . esc_html__( 'Debes iniciar sesión para gestionar tu empleado.', 'cdb-form' ) . '</p>';
     return;
 }
 
@@ -23,12 +23,12 @@ if (!empty($existing_empleado)) {
     $empleado_id         = $existing_empleado[0]->ID;
     $empleado_nombre     = get_the_title($empleado_id);
     $empleado_disponible = get_post_meta($empleado_id, 'disponible', true) ?: '1';
-    $button_text         = 'Actualizar Empleado';
+    $button_text         = __( 'Actualizar Empleado', 'cdb-form' );
 } else {
     $empleado_id         = 0;
     $empleado_nombre     = '';
     $empleado_disponible = '1';
-    $button_text         = 'Crear Empleado';
+    $button_text         = __( 'Crear Empleado', 'cdb-form' );
 }
 ?>
 
@@ -39,13 +39,13 @@ if (!empty($existing_empleado)) {
 
         <input type="hidden" name="empleado_id" value="<?php echo esc_attr($empleado_id); ?>">
 
-        <label for="nombre">Nombre:</label>
+        <label for="nombre"><?php esc_html_e( 'Nombre:', 'cdb-form' ); ?></label>
         <input type="text" id="nombre" name="nombre" value="<?php echo esc_attr($empleado_nombre); ?>" required>
 
-        <label for="disponible">Disponible:</label>
+        <label for="disponible"><?php esc_html_e( 'Disponible:', 'cdb-form' ); ?></label>
         <select id="disponible" name="disponible">
-            <option value="1" <?php selected($empleado_disponible, '1'); ?>>Sí</option>
-            <option value="0" <?php selected($empleado_disponible, '0'); ?>>No</option>
+            <option value="1" <?php selected($empleado_disponible, '1'); ?>><?php esc_html_e( 'Sí', 'cdb-form' ); ?></option>
+            <option value="0" <?php selected($empleado_disponible, '0'); ?>><?php esc_html_e( 'No', 'cdb-form' ); ?></option>
         </select>
 
         <button type="submit"><?php echo esc_html($button_text); ?></button>

--- a/templates/form-experiencia-template.php
+++ b/templates/form-experiencia-template.php
@@ -7,14 +7,14 @@ if (!defined('ABSPATH')) {
 // Verificar si el usuario está conectado.
 $current_user = wp_get_current_user();
 if (!$current_user->exists()) {
-    echo '<p>Debes iniciar sesión para gestionar tu empleado.</p>';
+    echo '<p>' . esc_html__( 'Debes iniciar sesión para gestionar tu empleado.', 'cdb-form' ) . '</p>';
     return;
 }
 
 // Obtener la ID del empleado asociado al usuario actual mediante la función específica.
 $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
 if (!$empleado_id) {
-    echo '<p>No tienes un perfil de empleado registrado. Para registrar experiencia, primero debes crear tu perfil de empleado.</p>';
+    echo '<p>' . esc_html__( 'No tienes un perfil de empleado registrado. Para registrar experiencia, primero debes crear tu perfil de empleado.', 'cdb-form' ) . '</p>';
     echo do_shortcode('[cdb_form_empleado]');
     return;
 }
@@ -190,13 +190,13 @@ error_log("[DEBUG] Bar ID: {$bar_id_actual} - Apertura: {$fecha_apertura} - Cier
             </tbody>
         </table>
     <?php else : ?>
-        <p>No tienes experiencia registrada aún.</p>
+        <p><?php esc_html_e( 'No tienes experiencia registrada aún.', 'cdb-form' ); ?></p>
     <?php endif; ?>
 </div>
 
 <!-- Formulario para agregar/actualizar experiencia -->
 <div class="cdb-experiencia-form">
-    <h2>Actualizar Experiencia Laboral</h2>
+    <h2><?php esc_html_e( 'Actualizar Experiencia Laboral', 'cdb-form' ); ?></h2>
     <form id="cdb_experiencia_form">
         <!-- Acción para el AJAX -->
         <input type="hidden" name="action" value="cdb_guardar_experiencia">

--- a/test.php
+++ b/test.php
@@ -2,7 +2,7 @@
 require_once('../../../wp-load.php'); // Asegurar carga de WordPress
 
 if (!is_user_logged_in()) {
-    die("Debes iniciar sesión.");
+    die( __( 'Debes iniciar sesión.', 'cdb-form' ) );
 }
 
 $current_user = wp_get_current_user();


### PR DESCRIPTION
## Summary
- introduce text domain and load textdomain on init
- internationalize all user-facing strings across the plugin
- regenerate translation template `cdb-form.pot`
- document how translations load in README

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_688c96f4c2208327817698c7ba0908e7