### PR TITLE
Add employee form design settings page

### DIFF
--- a/admin/diseno-empleado.php
+++ b/admin/diseno-empleado.php
@@ -1,0 +1,117 @@
+<?php
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Add admin menu for employee form design settings.
+ */
+function cdb_form_disenio_empleado_menu() {
+    add_menu_page(
+        __( 'Dise\xC3\xB1o de Empleado', 'cdb-form' ),
+        __( 'Dise\xC3\xB1o de Empleado', 'cdb-form' ),
+        'manage_options',
+        'cdb-form-disenio-empleado',
+        'cdb_form_disenio_empleado_page'
+    );
+}
+add_action( 'admin_menu', 'cdb_form_disenio_empleado_menu' );
+
+/**
+ * Render admin page and handle form submission.
+ */
+function cdb_form_disenio_empleado_page() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    // Defaults
+    $defaults = array(
+        'background_color'    => '#fafafa',
+        'border_color'        => '#ddd',
+        'text_color'          => '#000000',
+        'button_bg'           => '#000000',
+        'button_text_color'   => '#ffffff',
+        'font_size'           => 14,
+        'padding'             => 20,
+        'field_spacing'       => 10,
+        'message_color'       => '#008000',
+    );
+
+    // Handle save
+    if ( isset( $_POST['cdb_form_disenio_empleado_nonce'] ) &&
+         check_admin_referer( 'cdb_form_disenio_empleado_save', 'cdb_form_disenio_empleado_nonce' ) ) {
+
+        $options = array(
+            'background_color'  => sanitize_hex_color( $_POST['background_color'] ),
+            'border_color'      => sanitize_hex_color( $_POST['border_color'] ),
+            'text_color'        => sanitize_hex_color( $_POST['text_color'] ),
+            'button_bg'         => sanitize_hex_color( $_POST['button_bg'] ),
+            'button_text_color' => sanitize_hex_color( $_POST['button_text_color'] ),
+            'font_size'         => intval( $_POST['font_size'] ),
+            'padding'           => intval( $_POST['padding'] ),
+            'field_spacing'     => intval( $_POST['field_spacing'] ),
+            'message_color'     => sanitize_hex_color( $_POST['message_color'] ),
+        );
+
+        update_option( 'cdb_form_disenio_empleado', $options );
+        echo '<div class="updated"><p>' . esc_html__( 'Opciones guardadas.', 'cdb-form' ) . '</p></div>';
+    }
+
+    $values = wp_parse_args( get_option( 'cdb_form_disenio_empleado' ), $defaults );
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Dise\xC3\xB1o de Empleado', 'cdb-form' ); ?></h1>
+        <p><?php esc_html_e( 'Configura los estilos del formulario de empleado mostrado en el frontend. Estos cambios no afectan a otros formularios.', 'cdb-form' ); ?></p>
+        <form method="post">
+            <?php wp_nonce_field( 'cdb_form_disenio_empleado_save', 'cdb_form_disenio_empleado_nonce' ); ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row"><label for="background_color"><?php esc_html_e( 'Color de fondo del formulario', 'cdb-form' ); ?></label></th>
+                    <td><input type="text" id="background_color" class="cdb-color-field" name="background_color" value="<?php echo esc_attr( $values['background_color'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="border_color"><?php esc_html_e( 'Color del borde del formulario', 'cdb-form' ); ?></label></th>
+                    <td><input type="text" id="border_color" class="cdb-color-field" name="border_color" value="<?php echo esc_attr( $values['border_color'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="text_color"><?php esc_html_e( 'Color de texto de campos y etiquetas', 'cdb-form' ); ?></label></th>
+                    <td><input type="text" id="text_color" class="cdb-color-field" name="text_color" value="<?php echo esc_attr( $values['text_color'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="button_bg"><?php esc_html_e( 'Color de fondo del bot\xC3\xB3n', 'cdb-form' ); ?></label></th>
+                    <td><input type="text" id="button_bg" class="cdb-color-field" name="button_bg" value="<?php echo esc_attr( $values['button_bg'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="button_text_color"><?php esc_html_e( 'Color de texto del bot\xC3\xB3n', 'cdb-form' ); ?></label></th>
+                    <td><input type="text" id="button_text_color" class="cdb-color-field" name="button_text_color" value="<?php echo esc_attr( $values['button_text_color'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="font_size"><?php esc_html_e( 'Tama\xC3\xB1o de fuente de campos y etiquetas (px)', 'cdb-form' ); ?></label></th>
+                    <td><input type="number" id="font_size" name="font_size" value="<?php echo esc_attr( $values['font_size'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="padding"><?php esc_html_e( 'Padding del contenedor principal (px)', 'cdb-form' ); ?></label></th>
+                    <td><input type="number" id="padding" name="padding" value="<?php echo esc_attr( $values['padding'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="field_spacing"><?php esc_html_e( 'Espaciado vertical entre campos (px)', 'cdb-form' ); ?></label></th>
+                    <td><input type="number" id="field_spacing" name="field_spacing" value="<?php echo esc_attr( $values['field_spacing'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="message_color"><?php esc_html_e( 'Color de mensajes de \xC3\xA9xito y error', 'cdb-form' ); ?></label></th>
+                    <td><input type="text" id="message_color" class="cdb-color-field" name="message_color" value="<?php echo esc_attr( $values['message_color'] ); ?>" /></td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+    <script>
+    jQuery(function($){
+        $('.cdb-color-field').wpColorPicker();
+    });
+    </script>
+    <?php
+}
+

--- a/admin/enqueue.php
+++ b/admin/enqueue.php
@@ -7,9 +7,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Cargar estilos y scripts en el panel de administración
 function cdb_form_admin_enqueue( $hook ) {
     // Cargar solo en las páginas del plugin
-    if ( strpos( $hook, 'cdb_form' ) === false ) {
+    if ( strpos( $hook, 'cdb-form' ) === false ) {
         return;
     }
 
+    // Cargar el color picker en la página de diseño
+    if ( 'toplevel_page_cdb-form-disenio-empleado' === $hook ) {
+        wp_enqueue_style( 'wp-color-picker' );
+        wp_enqueue_script( 'wp-color-picker' );
+    }
 }
 add_action( 'admin_enqueue_scripts', 'cdb_form_admin_enqueue' );

--- a/includes/init.php
+++ b/includes/init.php
@@ -21,6 +21,7 @@ require_once CDB_FORM_PATH . 'includes/ajax-functions.php';
 
 // Cargar scripts y estilos para el admin y frontend
 require_once CDB_FORM_PATH . 'admin/enqueue.php';
+require_once CDB_FORM_PATH . 'admin/diseno-empleado.php';
 require_once CDB_FORM_PATH . 'public/enqueue.php';
 
 // Acción de inicialización del plugin

--- a/templates/form-empleado-template.php
+++ b/templates/form-empleado-template.php
@@ -30,6 +30,18 @@ if (!empty($existing_empleado)) {
     $empleado_disponible = '1';
     $button_text         = __( 'Crear Empleado', 'cdb-form' );
 }
+
+// Opciones de diseño
+$disenio = get_option('cdb_form_disenio_empleado');
+$cdb_background       = isset($disenio['background_color']) ? $disenio['background_color'] : '#fafafa';
+$cdb_border_color     = isset($disenio['border_color']) ? $disenio['border_color'] : '#ddd';
+$cdb_text_color       = isset($disenio['text_color']) ? $disenio['text_color'] : '#000';
+$cdb_button_bg        = isset($disenio['button_bg']) ? $disenio['button_bg'] : 'black';
+$cdb_button_text      = isset($disenio['button_text_color']) ? $disenio['button_text_color'] : 'white';
+$cdb_font_size        = isset($disenio['font_size']) ? intval($disenio['font_size']) : 14;
+$cdb_padding          = isset($disenio['padding']) ? intval($disenio['padding']) : 20;
+$cdb_field_spacing    = isset($disenio['field_spacing']) ? intval($disenio['field_spacing']) : 10;
+$cdb_message_color    = isset($disenio['message_color']) ? $disenio['message_color'] : '#008000';
 ?>
 
 <div class="cdb-empleado-container">
@@ -54,7 +66,7 @@ if (!empty($existing_empleado)) {
 
 <style>
     .cdb-empleado-container {
-        padding: 20px;
+        padding: <?php echo esc_attr($cdb_padding); ?>px;
         border: 1px solid #ddd;
         border-radius: 8px;
         background-color: #fff;
@@ -71,24 +83,28 @@ if (!empty($existing_empleado)) {
     #cdb-form-empleado {
         margin-top: 20px;
         padding: 15px;
-        background: #fafafa;
-        border: 1px solid #ddd;
+        background: <?php echo esc_attr($cdb_background); ?>;
+        border: 1px solid <?php echo esc_attr($cdb_border_color); ?>;
         border-radius: 8px;
     }
 
     #cdb-form-empleado label {
         font-weight: bold;
         display: block;
-        margin-top: 10px;
+        margin-top: <?php echo esc_attr($cdb_field_spacing); ?>px;
+        color: <?php echo esc_attr($cdb_text_color); ?>;
+        font-size: <?php echo esc_attr($cdb_font_size); ?>px;
     }
 
     #cdb-form-empleado input,
     #cdb-form-empleado select {
         width: 100%;
         padding: 8px;
-        margin-top: 5px;
+        margin-bottom: <?php echo esc_attr($cdb_field_spacing); ?>px;
         border: 1px solid #ccc;
         border-radius: 4px;
+        color: <?php echo esc_attr($cdb_text_color); ?>;
+        font-size: <?php echo esc_attr($cdb_font_size); ?>px;
     }
 
     #cdb-form-empleado button {
@@ -96,8 +112,8 @@ if (!empty($existing_empleado)) {
         width: 100%;
         padding: 10px;
         margin-top: 15px;
-        background: black;
-        color: white;
+        background: <?php echo esc_attr($cdb_button_bg); ?>;
+        color: <?php echo esc_attr($cdb_button_text); ?>;
         border: none;
         border-radius: 4px;
         cursor: pointer;
@@ -105,6 +121,11 @@ if (!empty($existing_empleado)) {
 
     #cdb-form-empleado button:hover {
         background: #333;
+    }
+
+    .cdb-form-message.success,
+    .cdb-form-message.error {
+        color: <?php echo esc_attr($cdb_message_color); ?>;
     }
 </style>
 
@@ -135,3 +156,4 @@ jQuery(document).ready(function($) {
     });
 });
 </script>
+


### PR DESCRIPTION
## Summary
- add admin menu page `Diseño de Empleado`
- load WP color picker on the admin page
- include new page in plugin init
- apply saved style options when rendering the employee form template

## Testing
- `php -l admin/diseno-empleado.php`
- `php -l admin/enqueue.php`
- `php -l includes/init.php`
- `php -l templates/form-empleado-template.php`
- `php -l cdb-form.php`

------
https://chatgpt.com/codex/tasks/task_e_688ca4e8cd008327867f9eff082f8c50