### PR TITLE
Implement advanced employee search

### DIFF
--- a/assets/js/frontend-scripts.js
+++ b/assets/js/frontend-scripts.js
@@ -60,16 +60,61 @@ jQuery(document).ready(function($) {
             }
         });
     });
-    // Buscador de empleados automático
+    // Buscador avanzado de empleados con AJAX
+    function cdbBuscarEmpleados() {
+        var data = {
+            action: 'cdb_buscar_empleados',
+            nonce: cdb_form_ajax.nonce,
+            nombre: jQuery('#cdb-nombre').val(),
+            posicion_id: jQuery('#cdb-posicion-id').val(),
+            bar_id: jQuery('#cdb-bar-id').val(),
+            anio: jQuery('#cdb-anio').val()
+        };
+        jQuery.getJSON(cdb_form_ajax.ajaxurl, data, function(resp){
+            if(resp.success){
+                jQuery('#cdb-busqueda-empleados-resultados').html(resp.data.html);
+            }
+        });
+    }
+
     var cdbBusquedaTimer;
-    $("#cdb-busqueda-empleados-form").on("change", "select", function(){
-        $("#cdb-busqueda-empleados-form").submit();
-    });
-    $("#cdb-busqueda-empleados-form input[name="nombre"]").on("keyup", function(){
+    jQuery('#cdb-busqueda-empleados input').on('keyup change', function(){
         clearTimeout(cdbBusquedaTimer);
-        cdbBusquedaTimer = setTimeout(function(){
-            $("#cdb-busqueda-empleados-form").submit();
-        }, 500);
+        cdbBusquedaTimer = setTimeout(cdbBuscarEmpleados, 500);
     });
+
+    // Autocompletados
+    jQuery('#cdb-nombre').autocomplete({
+        source: function(request, response){
+            jQuery.getJSON(cdb_form_ajax.ajaxurl, {action:'cdb_sugerencias', nonce:cdb_form_ajax.nonce, tipo:'nombre', term:request.term}, response);
+        },
+        minLength:2
+    });
+
+    jQuery('#cdb-posicion').autocomplete({
+        source: function(request, response){
+            jQuery.getJSON(cdb_form_ajax.ajaxurl, {action:'cdb_sugerencias', nonce:cdb_form_ajax.nonce, tipo:'posicion', term:request.term}, response);
+        },
+        minLength:2,
+        select: function(e,ui){ jQuery('#cdb-posicion-id').val(ui.item.id); }
+    }).on('keyup', function(){ jQuery('#cdb-posicion-id').val(''); });
+
+    jQuery('#cdb-bar').autocomplete({
+        source: function(request, response){
+            jQuery.getJSON(cdb_form_ajax.ajaxurl, {action:'cdb_sugerencias', nonce:cdb_form_ajax.nonce, tipo:'bar', term:request.term}, response);
+        },
+        minLength:2,
+        select: function(e,ui){ jQuery('#cdb-bar-id').val(ui.item.id); }
+    }).on('keyup', function(){ jQuery('#cdb-bar-id').val(''); });
+
+    jQuery('#cdb-anio').autocomplete({
+        source: function(request, response){
+            jQuery.getJSON(cdb_form_ajax.ajaxurl, {action:'cdb_sugerencias', nonce:cdb_form_ajax.nonce, tipo:'anio', term:request.term}, response);
+        },
+        minLength:1
+    });
+
+    // Carga inicial
+    cdbBuscarEmpleados();
 });
 

--- a/cdb-form.php
+++ b/cdb-form.php
@@ -105,9 +105,9 @@ add_action('wp_ajax_cdb_refrescar_top_21', 'cdb_refrescar_top_21');
 add_action('wp_ajax_nopriv_cdb_refrescar_top_21', 'cdb_refrescar_top_21');
 
 function cdb_form_enqueue_scripts_conditionally() {
-    // Verificar si se está usando el shortcode [cdb_experiencia], por ejemplo:
+    // Verificar si se usa [cdb_experiencia] o [cdb_busqueda_empleados]
     global $post;
-    if ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'cdb_experiencia' ) ) {
+    if ( is_a( $post, 'WP_Post' ) && ( has_shortcode( $post->post_content, 'cdb_experiencia' ) || has_shortcode( $post->post_content, 'cdb_busqueda_empleados' ) ) ) {
         wp_enqueue_script('jquery-ui-autocomplete');
         wp_enqueue_style(
             'cdb-form-jquery-ui-css',

--- a/templates/busqueda-empleados-table.php
+++ b/templates/busqueda-empleados-table.php
@@ -1,0 +1,34 @@
+<?php if ( empty( $empleados ) ) : ?>
+    <p><?php esc_html_e( 'No se encontraron empleados con esos filtros.', 'cdb-form' ); ?></p>
+<?php else : ?>
+<table class="cdb-busqueda-table">
+    <thead>
+        <tr>
+            <th><?php esc_html_e( 'Puntuaci\xC3\xB3n', 'cdb-form' ); ?></th>
+            <th><?php esc_html_e( 'Nombre', 'cdb-form' ); ?></th>
+            <th><?php esc_html_e( 'Posiciones', 'cdb-form' ); ?></th>
+            <th><?php esc_html_e( 'Bares', 'cdb-form' ); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach ( $empleados as $emp ) : ?>
+        <tr>
+            <td><?php echo esc_html( $emp['puntuacion'] ); ?></td>
+            <td><a href="<?php echo esc_url( get_permalink( $emp['id'] ) ); ?>"><?php echo esc_html( $emp['nombre'] ); ?></a></td>
+            <td>
+                <?php foreach ( $emp['posiciones'] as $index => $pos ) : ?>
+                    <?php if ( $index > 0 ) echo ', '; ?>
+                    <a href="<?php echo esc_url( get_permalink( $pos['id'] ) ); ?>"><?php echo esc_html( $pos['nombre'] ); ?></a>
+                <?php endforeach; ?>
+            </td>
+            <td>
+                <?php foreach ( $emp['bares'] as $index => $bar ) : ?>
+                    <?php if ( $index > 0 ) echo ', '; ?>
+                    <a href="<?php echo esc_url( get_permalink( $bar['id'] ) ); ?>"><?php echo esc_html( $bar['nombre'] ); ?></a>
+                <?php endforeach; ?>
+            </td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+<?php endif; ?>

--- a/templates/busqueda-empleados.php
+++ b/templates/busqueda-empleados.php
@@ -1,74 +1,25 @@
 <?php
-// Plantilla para el shortcode [cdb_busqueda_empleados]
+// Nueva plantilla para [cdb_busqueda_empleados]
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 ?>
 <style>
 .cdb-busqueda-filtros{margin-bottom:1em;display:flex;flex-wrap:wrap;gap:10px}
-.cdb-busqueda-filtros select,.cdb-busqueda-filtros input{padding:4px}
+.cdb-busqueda-filtros input{padding:4px}
 .cdb-busqueda-table{width:100%;border-collapse:collapse}
 .cdb-busqueda-table th,.cdb-busqueda-table td{padding:6px;border-bottom:1px solid #ccc;text-align:left}
 </style>
-<form id="cdb-busqueda-empleados-form" class="cdb-busqueda-filtros" method="get">
-    <select name="bar_id">
-        <option value="0"><?php esc_html_e('Todos los Bares','cdb-form'); ?></option>
-        <?php foreach($opciones_bar as $id=>$nombre): ?>
-            <option value="<?php echo esc_attr($id); ?>" <?php selected($bar_id,$id); ?>><?php echo esc_html($nombre); ?></option>
-        <?php endforeach; ?>
-    </select>
-    <select name="equipo_id">
-        <option value="0"><?php esc_html_e('Todos los Equipos','cdb-form'); ?></option>
-        <?php foreach($opciones_equipo as $id=>$nombre): ?>
-            <option value="<?php echo esc_attr($id); ?>" <?php selected($equipo_id,$id); ?>><?php echo esc_html($nombre); ?></option>
-        <?php endforeach; ?>
-    </select>
-    <select name="posicion_id">
-        <option value="0"><?php esc_html_e('Todas las Posiciones','cdb-form'); ?></option>
-        <?php foreach($opciones_posicion as $id=>$nombre): ?>
-            <option value="<?php echo esc_attr($id); ?>" <?php selected($posicion_id,$id); ?>><?php echo esc_html($nombre); ?></option>
-        <?php endforeach; ?>
-    </select>
-    <select name="anio">
-        <option value="0"><?php esc_html_e('Todos los Años','cdb-form'); ?></option>
-        <?php foreach($opciones_anio as $valor): ?>
-            <option value="<?php echo esc_attr($valor); ?>" <?php selected($anio,$valor); ?>><?php echo esc_html($valor); ?></option>
-        <?php endforeach; ?>
-    </select>
-    <input type="text" name="nombre" placeholder="<?php esc_attr_e('Nombre','cdb-form'); ?>" value="<?php echo esc_attr($nombre); ?>" />
-    <select name="disponible">
-        <option value=""><?php esc_html_e('Disponibilidad','cdb-form'); ?></option>
-        <option value="1" <?php selected($disponible,'1'); ?>><?php esc_html_e('Disponible','cdb-form'); ?></option>
-        <option value="0" <?php if($disponible==='0') echo 'selected'; ?>><?php esc_html_e('No disponible','cdb-form'); ?></option>
-    </select>
-</form>
-<?php if(empty($empleados)): ?>
-    <p><?php esc_html_e('No se encontraron empleados con esos filtros.','cdb-form'); ?></p>
-<?php else: ?>
-<table class="cdb-busqueda-table">
-    <thead>
-        <tr>
-            <th><?php esc_html_e('Año','cdb-form'); ?></th>
-            <th><?php esc_html_e('Empleado','cdb-form'); ?></th>
-            <th><?php esc_html_e('Posición','cdb-form'); ?></th>
-            <th><?php esc_html_e('Bar','cdb-form'); ?></th>
-            <th><?php esc_html_e('Equipo','cdb-form'); ?></th>
-            <th><?php esc_html_e('Puntuación','cdb-form'); ?></th>
-            <th><?php esc_html_e('Disponibilidad','cdb-form'); ?></th>
-        </tr>
-    </thead>
-    <tbody>
-    <?php foreach($empleados as $emp): ?>
-        <tr>
-            <td><?php echo esc_html($emp['anio']); ?></td>
-            <td><a href="<?php echo esc_url($emp['url']); ?>"><?php echo esc_html($emp['nombre']); ?></a></td>
-            <td><?php echo esc_html($emp['posicion']); ?></td>
-            <td><?php echo esc_html($emp['bar']); ?></td>
-            <td><?php echo esc_html($emp['equipo']); ?></td>
-            <td><?php echo esc_html($emp['puntuacion']); ?></td>
-            <td><?php echo esc_html($emp['disponible']); ?></td>
-        </tr>
-    <?php endforeach; ?>
-    </tbody>
-</table>
-<?php endif; ?>
+<div id="cdb-busqueda-empleados">
+    <div class="cdb-busqueda-filtros">
+        <input type="text" id="cdb-nombre" placeholder="<?php esc_attr_e('Nombre','cdb-form'); ?>" />
+        <input type="text" id="cdb-posicion" placeholder="<?php esc_attr_e('Posici\xC3\xB3n','cdb-form'); ?>" />
+        <input type="hidden" id="cdb-posicion-id" />
+        <input type="text" id="cdb-bar" placeholder="<?php esc_attr_e('Bar','cdb-form'); ?>" />
+        <input type="hidden" id="cdb-bar-id" />
+        <input type="text" id="cdb-anio" placeholder="<?php esc_attr_e('A\xC3\xB1o','cdb-form'); ?>" />
+    </div>
+    <div id="cdb-busqueda-empleados-resultados">
+        <?php include CDB_FORM_PATH . 'templates/busqueda-empleados-table.php'; ?>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add AJAX-powered search for employees with autocomplete
- create new templates for the search form and results table
- provide new AJAX endpoints for employee search and autocomplete
- update frontend JS to request suggestions and results dynamically
- load jQuery UI when the search shortcode is present

## Testing
- `php -l cdb-form.php`
- `php -l includes/shortcodes.php`
- `php -l includes/ajax-functions.php`
- `php -l templates/busqueda-empleados.php`
- `php -l templates/busqueda-empleados-table.php`
- `php -l assets/js/frontend-scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_688cf7d5b8fc832798df6b5737f89103