### PR TITLE
Fix misencoded Spanish characters

### DIFF
--- a/templates/busqueda-empleados-table.php
+++ b/templates/busqueda-empleados-table.php
@@ -4,7 +4,7 @@
 <table class="cdb-busqueda-table">
     <thead>
         <tr>
-            <th><?php esc_html_e( 'Puntuaci\xC3\xB3n', 'cdb-form' ); ?></th>
+            <th><?php esc_html_e( 'Puntuación', 'cdb-form' ); ?></th>
             <th><?php esc_html_e( 'Nombre', 'cdb-form' ); ?></th>
             <th><?php esc_html_e( 'Posiciones', 'cdb-form' ); ?></th>
             <th><?php esc_html_e( 'Bares', 'cdb-form' ); ?></th>

--- a/templates/busqueda-empleados.php
+++ b/templates/busqueda-empleados.php
@@ -13,11 +13,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div id="cdb-busqueda-empleados">
     <div class="cdb-busqueda-filtros">
         <input type="text" id="cdb-nombre" placeholder="<?php esc_attr_e('Nombre','cdb-form'); ?>" />
-        <input type="text" id="cdb-posicion" placeholder="<?php esc_attr_e('Posici\xC3\xB3n','cdb-form'); ?>" />
+        <input type="text" id="cdb-posicion" placeholder="<?php esc_attr_e('Posición','cdb-form'); ?>" />
         <input type="hidden" id="cdb-posicion-id" />
         <input type="text" id="cdb-bar" placeholder="<?php esc_attr_e('Bar','cdb-form'); ?>" />
         <input type="hidden" id="cdb-bar-id" />
-        <input type="text" id="cdb-anio" placeholder="<?php esc_attr_e('A\xC3\xB1o','cdb-form'); ?>" />
+        <input type="text" id="cdb-anio" placeholder="<?php esc_attr_e('Año','cdb-form'); ?>" />
     </div>
     <div id="cdb-busqueda-empleados-resultados">
         <?php include CDB_FORM_PATH . 'templates/busqueda-empleados-table.php'; ?>


### PR DESCRIPTION
## Summary
- fix misencoded placeholders in `busqueda-empleados.php`
- fix table header text in `busqueda-empleados-table.php`

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_688cfc6bf5e08327ba394811d164c6bf