### PR TITLE
Add filter button and autocomplete

### DIFF
--- a/assets/js/frontend-scripts.js
+++ b/assets/js/frontend-scripts.js
@@ -77,13 +77,15 @@ jQuery(document).ready(function($) {
         });
     }
 
-    var cdbBusquedaTimer;
-    jQuery('#cdb-busqueda-empleados input').on('keyup change', function(){
-        clearTimeout(cdbBusquedaTimer);
-        cdbBusquedaTimer = setTimeout(cdbBuscarEmpleados, 500);
+
+    // Ejecuta la búsqueda solo cuando el usuario pulsa el botón "Filtrar"
+    jQuery('#cdb-filtrar').on('click', function(){
+        cdbBuscarEmpleados();
     });
 
     // Autocompletados
+    // Si se añaden más filtros, replicar esta llamada cambiando el parámetro
+    // "tipo" para que el backend devuelva las sugerencias correspondientes.
     jQuery('#cdb-nombre').autocomplete({
         source: function(request, response){
             jQuery.getJSON(cdb_form_ajax.ajaxurl, {action:'cdb_sugerencias', nonce:cdb_form_ajax.nonce, tipo:'nombre', term:request.term}, response);

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -396,6 +396,9 @@ function cdb_busqueda_sugerencias_ajax() {
     $term = isset( $_GET['term'] ) ? sanitize_text_field( $_GET['term'] ) : '';
 
     $results = array();
+    // Dependiendo del tipo se consultan los posts o la tabla de experiencia.
+    // Para añadir nuevos filtros, basta con agregar otro "case" que devuelva
+    // las opciones pertinentes.
     switch ( $tipo ) {
         case 'nombre':
             $ids = get_posts( array(

--- a/templates/busqueda-empleados.php
+++ b/templates/busqueda-empleados.php
@@ -5,8 +5,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <style>
-.cdb-busqueda-filtros{margin-bottom:1em;display:flex;flex-wrap:wrap;gap:10px}
+.cdb-busqueda-filtros{margin-bottom:1em;display:flex;flex-wrap:wrap;gap:10px;align-items:flex-end}
 .cdb-busqueda-filtros input{padding:4px}
+.cdb-btn-filtrar{padding:6px 12px;background:#000;color:#FAF8EE;border:0;border-radius:4px;cursor:pointer}
+.cdb-btn-filtrar:hover{background:#444}
 .cdb-busqueda-table{width:100%;border-collapse:collapse}
 .cdb-busqueda-table th,.cdb-busqueda-table td{padding:6px;border-bottom:1px solid #ccc;text-align:left}
 </style>
@@ -18,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
         <input type="text" id="cdb-bar" placeholder="<?php esc_attr_e('Bar','cdb-form'); ?>" />
         <input type="hidden" id="cdb-bar-id" />
         <input type="text" id="cdb-anio" placeholder="<?php esc_attr_e('Año','cdb-form'); ?>" />
+        <button id="cdb-filtrar" class="cdb-btn-filtrar" type="button"><?php esc_html_e('Filtrar','cdb-form'); ?></button>
     </div>
     <div id="cdb-busqueda-empleados-resultados">
         <?php include CDB_FORM_PATH . 'templates/busqueda-empleados-table.php'; ?>


### PR DESCRIPTION
## Summary
- add button and styles to the employee search template
- adjust JS to trigger search only when the user clicks the filter button
- document how to extend the autocomplete endpoint

## Testing
- `php -l templates/busqueda-empleados.php`
- `php -l assets/js/frontend-scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_688cff31cfb483278e79950ab63f5d50