### PR TITLE
Implement Awesomplete-based employee search

### DIFF
--- a/cdb-form.php
+++ b/cdb-form.php
@@ -107,13 +107,33 @@ add_action('wp_ajax_nopriv_cdb_refrescar_top_21', 'cdb_refrescar_top_21');
 function cdb_form_enqueue_scripts_conditionally() {
     // Verificar si se usa [cdb_experiencia] o [cdb_busqueda_empleados]
     global $post;
-    if ( is_a( $post, 'WP_Post' ) && ( has_shortcode( $post->post_content, 'cdb_experiencia' ) || has_shortcode( $post->post_content, 'cdb_busqueda_empleados' ) ) ) {
-        wp_enqueue_script('jquery-ui-autocomplete');
+    if ( ! is_a( $post, 'WP_Post' ) ) {
+        return;
+    }
+
+    if ( has_shortcode( $post->post_content, 'cdb_experiencia' ) ) {
+        wp_enqueue_script( 'jquery-ui-autocomplete' );
         wp_enqueue_style(
             'cdb-form-jquery-ui-css',
             'https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css',
             array(),
             '1.12.1'
+        );
+    }
+
+    if ( has_shortcode( $post->post_content, 'cdb_busqueda_empleados' ) ) {
+        wp_enqueue_script(
+            'awesomplete',
+            'https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.5/awesomplete.min.js',
+            array(),
+            '1.1.5',
+            true
+        );
+        wp_enqueue_style(
+            'awesomplete',
+            'https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.5/awesomplete.min.css',
+            array(),
+            '1.1.5'
         );
     }
 }

--- a/templates/busqueda-empleados.php
+++ b/templates/busqueda-empleados.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 .cdb-btn-filtrar:hover{background:#444}
 .cdb-busqueda-table{width:100%;border-collapse:collapse}
 .cdb-busqueda-table th,.cdb-busqueda-table td{padding:6px;border-bottom:1px solid #ccc;text-align:left}
+#cdb-busqueda-spinner{display:none;margin-top:10px}
 </style>
 <div id="cdb-busqueda-empleados">
     <div class="cdb-busqueda-filtros">
@@ -21,8 +22,10 @@ if ( ! defined( 'ABSPATH' ) ) {
         <input type="hidden" id="cdb-bar-id" />
         <input type="text" id="cdb-anio" placeholder="<?php esc_attr_e('Año','cdb-form'); ?>" />
         <button id="cdb-filtrar" class="cdb-btn-filtrar" type="button"><?php esc_html_e('Filtrar','cdb-form'); ?></button>
+        <button id="cdb-limpiar" class="cdb-btn-filtrar" type="button"><?php esc_html_e('Limpiar','cdb-form'); ?></button>
     </div>
     <div id="cdb-busqueda-empleados-resultados">
         <?php include CDB_FORM_PATH . 'templates/busqueda-empleados-table.php'; ?>
     </div>
+    <div id="cdb-busqueda-spinner"><?php esc_html_e('Cargando...','cdb-form'); ?></div>
 </div>


### PR DESCRIPTION
## Summary
- integrate Awesomplete library for advanced autocomplete
- add loading spinner, clear button and validation in search template
- update JS to fetch suggestions via AJAX and validate inputs
- conditionally enqueue Awesomplete assets

## Testing
- `php -l cdb-form.php`
- `php -l templates/busqueda-empleados.php`
- `node --check assets/js/frontend-scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_688d054d96f88327aa653ffbcea4b6a8