### PR TITLE
Handle deferred Awesomplete initialization

### DIFF
--- a/assets/js/frontend-scripts.js
+++ b/assets/js/frontend-scripts.js
@@ -83,147 +83,163 @@ jQuery(document).ready(function($) {
     }
 
 
-    var filtrarBtn = document.getElementById('cdb-filtrar');
-    if (filtrarBtn) {
-        filtrarBtn.addEventListener('click', function(){
-            if (validarFiltros()) {
+    var nombreInput, posInput, posIdInput, barInput, barIdInput, anioInput;
+    var filtrarBtn, limpiarBtn;
+
+    function initBusqueda(){
+        nombreInput   = document.getElementById('cdb-nombre');
+        posInput      = document.getElementById('cdb-posicion');
+        posIdInput    = document.getElementById('cdb-posicion-id');
+        barInput      = document.getElementById('cdb-bar');
+        barIdInput    = document.getElementById('cdb-bar-id');
+        anioInput     = document.getElementById('cdb-anio');
+        filtrarBtn    = document.getElementById('cdb-filtrar');
+        limpiarBtn    = document.getElementById('cdb-limpiar');
+
+        if (!nombreInput || !posInput || !barInput || !anioInput) {
+            return; // search form not present
+        }
+
+        if (!window.Awesomplete) {
+            return false;
+        }
+
+        if (filtrarBtn) {
+            filtrarBtn.addEventListener('click', function(){
+                if (validarFiltros()) {
+                    cdbBuscarEmpleados();
+                }
+            });
+        }
+
+        if (limpiarBtn) {
+            limpiarBtn.addEventListener('click', function(){
+                nombreInput.value = '';
+                posInput.value = '';
+                barInput.value = '';
+                anioInput.value = '';
+                posIdInput.value = '';
+                barIdInput.value = '';
+                nombreInput.dataset.valid = '';
+                posInput.dataset.valid = '';
+                barInput.dataset.valid = '';
+                anioInput.dataset.valid = '';
                 cdbBuscarEmpleados();
-            }
-        });
-    }
+            });
+        }
 
-    var limpiarBtn = document.getElementById('cdb-limpiar');
-    if (limpiarBtn) {
-        limpiarBtn.addEventListener('click', function(){
-            nombreInput.value = '';
-            posInput.value = '';
-            barInput.value = '';
-            anioInput.value = '';
-            posIdInput.value = '';
-            barIdInput.value = '';
+        function obtenerSugerencias(tipo, termino, callback){
+            jQuery.getJSON(cdb_form_ajax.ajaxurl, {
+                action: 'cdb_sugerencias',
+                nonce: cdb_form_ajax.nonce,
+                tipo: tipo,
+                term: termino
+            }, callback);
+        }
+
+        var posSugs = [], barSugs = [];
+
+        var awNombre  = new Awesomplete(nombreInput, { minChars:1, autoFirst:true });
+        nombreInput.addEventListener('input', function(){
             nombreInput.dataset.valid = '';
+            obtenerSugerencias('nombre', this.value, function(res){
+                awNombre.list = res.map(function(r){ return r.label; });
+            });
+        });
+        nombreInput.addEventListener('awesomplete-selectcomplete', function(){
+            nombreInput.dataset.valid = '1';
+        });
+
+        var awPos = new Awesomplete(posInput, { minChars:1, autoFirst:true });
+        posInput.addEventListener('input', function(){
             posInput.dataset.valid = '';
-            barInput.dataset.valid = '';
-            anioInput.dataset.valid = '';
-            cdbBuscarEmpleados();
+            posIdInput.value = '';
+            obtenerSugerencias('posicion', this.value, function(res){
+                posSugs = res;
+                awPos.list = res.map(function(r){ return r.label; });
+            });
         });
-    }
-
-    // ----- Awesomplete Autocompletado -----
-    function obtenerSugerencias(tipo, termino, callback){
-        jQuery.getJSON(cdb_form_ajax.ajaxurl, {
-            action: 'cdb_sugerencias',
-            nonce: cdb_form_ajax.nonce,
-            tipo: tipo,
-            term: termino
-        }, callback);
-    }
-
-    var nombreInput   = document.getElementById('cdb-nombre');
-    var posInput      = document.getElementById('cdb-posicion');
-    var posIdInput    = document.getElementById('cdb-posicion-id');
-    var barInput      = document.getElementById('cdb-bar');
-    var barIdInput    = document.getElementById('cdb-bar-id');
-    var anioInput     = document.getElementById('cdb-anio');
-
-    if (!nombreInput || !posInput || !barInput || !anioInput) {
-        return; // search form not present
-    }
-
-    var posSugs = [], barSugs = [];
-
-    var awNombre  = new Awesomplete(nombreInput, { minChars:1, autoFirst:true });
-    nombreInput.addEventListener('input', function(){
-        nombreInput.dataset.valid = '';
-        obtenerSugerencias('nombre', this.value, function(res){
-            awNombre.list = res.map(function(r){ return r.label; });
-        });
-    });
-    nombreInput.addEventListener('awesomplete-selectcomplete', function(){
-        nombreInput.dataset.valid = '1';
-    });
-
-    var awPos = new Awesomplete(posInput, { minChars:1, autoFirst:true });
-    posInput.addEventListener('input', function(){
-        posInput.dataset.valid = '';
-        posIdInput.value = '';
-        obtenerSugerencias('posicion', this.value, function(res){
-            posSugs = res;
-            awPos.list = res.map(function(r){ return r.label; });
-        });
-    });
-    posInput.addEventListener('awesomplete-selectcomplete', function(){
-        var val = posInput.value;
-        var obj = posSugs.find(function(i){ return i.label === val; });
-        if(obj){
-            posIdInput.value = obj.id;
-            posInput.dataset.valid = '1';
-        }
-    });
-
-    var awBar = new Awesomplete(barInput, { minChars:1, autoFirst:true });
-    barInput.addEventListener('input', function(){
-        barInput.dataset.valid = '';
-        barIdInput.value = '';
-        obtenerSugerencias('bar', this.value, function(res){
-            barSugs = res;
-            awBar.list = res.map(function(r){ return r.label; });
-        });
-    });
-    barInput.addEventListener('awesomplete-selectcomplete', function(){
-        var val = barInput.value;
-        var obj = barSugs.find(function(i){ return i.label === val; });
-        if(obj){
-            barIdInput.value = obj.id;
-            barInput.dataset.valid = '1';
-        }
-    });
-
-    var awAnio = new Awesomplete(anioInput, { minChars:1, autoFirst:true });
-    anioInput.addEventListener('input', function(){
-        anioInput.dataset.valid = '';
-        obtenerSugerencias('anio', this.value, function(res){
-            awAnio.list = res.map(function(r){ return r.label; });
-        });
-    });
-    anioInput.addEventListener('awesomplete-selectcomplete', function(){
-        anioInput.dataset.valid = '1';
-    });
-
-    [nombreInput, posInput, barInput, anioInput].forEach(function(el){
-        el.addEventListener('keydown', function(e){
-            if(e.key === 'Enter'){
-                e.preventDefault();
-                if (filtrarBtn) filtrarBtn.click();
+        posInput.addEventListener('awesomplete-selectcomplete', function(){
+            var val = posInput.value;
+            var obj = posSugs.find(function(i){ return i.label === val; });
+            if(obj){
+                posIdInput.value = obj.id;
+                posInput.dataset.valid = '1';
             }
         });
-    });
 
-    function validarFiltros(){
-        if(anioInput.value && !/^[0-9]{4}$/.test(anioInput.value)){
-            alert('El año debe tener 4 cifras');
-            return false;
+        var awBar = new Awesomplete(barInput, { minChars:1, autoFirst:true });
+        barInput.addEventListener('input', function(){
+            barInput.dataset.valid = '';
+            barIdInput.value = '';
+            obtenerSugerencias('bar', this.value, function(res){
+                barSugs = res;
+                awBar.list = res.map(function(r){ return r.label; });
+            });
+        });
+        barInput.addEventListener('awesomplete-selectcomplete', function(){
+            var val = barInput.value;
+            var obj = barSugs.find(function(i){ return i.label === val; });
+            if(obj){
+                barIdInput.value = obj.id;
+                barInput.dataset.valid = '1';
+            }
+        });
+
+        var awAnio = new Awesomplete(anioInput, { minChars:1, autoFirst:true });
+        anioInput.addEventListener('input', function(){
+            anioInput.dataset.valid = '';
+            obtenerSugerencias('anio', this.value, function(res){
+                awAnio.list = res.map(function(r){ return r.label; });
+            });
+        });
+        anioInput.addEventListener('awesomplete-selectcomplete', function(){
+            anioInput.dataset.valid = '1';
+        });
+
+        [nombreInput, posInput, barInput, anioInput].forEach(function(el){
+            el.addEventListener('keydown', function(e){
+                if(e.key === 'Enter'){
+                    e.preventDefault();
+                    if (filtrarBtn) filtrarBtn.click();
+                }
+            });
+        });
+
+        function validarFiltros(){
+            if(anioInput.value && !/^[0-9]{4}$/.test(anioInput.value)){
+                alert('El año debe tener 4 cifras');
+                return false;
+            }
+            if(nombreInput.value && !nombreInput.dataset.valid){
+                alert('Selecciona un nombre válido');
+                return false;
+            }
+            if(posInput.value && !posInput.dataset.valid){
+                alert('Selecciona una posición válida');
+                return false;
+            }
+            if(barInput.value && !barInput.dataset.valid){
+                alert('Selecciona un bar válido');
+                return false;
+            }
+            if(anioInput.value && !anioInput.dataset.valid){
+                alert('Selecciona un año válido');
+                return false;
+            }
+            return true;
         }
-        if(nombreInput.value && !nombreInput.dataset.valid){
-            alert('Selecciona un nombre válido');
-            return false;
-        }
-        if(posInput.value && !posInput.dataset.valid){
-            alert('Selecciona una posición válida');
-            return false;
-        }
-        if(barInput.value && !barInput.dataset.valid){
-            alert('Selecciona un bar válido');
-            return false;
-        }
-        if(anioInput.value && !anioInput.dataset.valid){
-            alert('Selecciona un año válido');
-            return false;
-        }
+
+        // Carga inicial
+        cdbBuscarEmpleados();
+
         return true;
     }
 
-    // Carga inicial
-    cdbBuscarEmpleados();
+    var initResult = initBusqueda();
+    if (initResult === false) {
+        document.addEventListener('awesomplete-loaded', initBusqueda, { once: true });
+        setTimeout(initBusqueda, 50);
+    }
 });
 

--- a/cdb-form.php
+++ b/cdb-form.php
@@ -137,6 +137,7 @@ function cdb_form_enqueue_scripts_conditionally() {
             array(),
             '1.1.5'
         );
+        wp_add_inline_script('awesomplete', 'document.dispatchEvent(new Event("awesomplete-loaded"));');
 
         // Encolar el script principal después de Awesomplete
         wp_enqueue_script( 'cdb-form-frontend-script' );


### PR DESCRIPTION
## Summary
- emit a custom `awesomplete-loaded` event after enqueuing the library
- wait for the Awesomplete script before attaching autocompletes

## Testing
- `php -l cdb-form.php`
- `php -l assets/js/frontend-scripts.js`
- `node --check assets/js/frontend-scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_688d0d0745188327aeb46a91c0801557