### PR TITLE
Fix AJAX permission handling for search

### DIFF
--- a/assets/js/frontend-scripts.js
+++ b/assets/js/frontend-scripts.js
@@ -77,8 +77,14 @@ jQuery(document).ready(function($) {
         jQuery.getJSON(cdb_form_ajax.ajaxurl, params, function(resp){
             if(resp.success){
                 jQuery('#cdb-busqueda-empleados-resultados').html(resp.data.html);
+            } else if (resp.data && resp.data.message) {
+                alert(resp.data.message);
             }
             if (spinner) spinner.style.display = 'none';
+        }).fail(function(jqXHR){
+            if (spinner) spinner.style.display = 'none';
+            alert('Error de comunicación');
+            console.error('cdb_buscar_empleados AJAX fail', jqXHR);
         });
     }
 
@@ -134,7 +140,9 @@ jQuery(document).ready(function($) {
                 nonce: cdb_form_ajax.nonce,
                 tipo: tipo,
                 term: termino
-            }, callback);
+            }, callback).fail(function(jqXHR){
+                console.error('cdb_sugerencias AJAX fail', jqXHR);
+            });
         }
 
         var posSugs = [], barSugs = [];

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -362,7 +362,12 @@ add_action( 'wp_ajax_nopriv_cdb_listar_experiencias', 'cdb_listar_experiencias' 
  * Devuelve resultados HTML para el buscador avanzado de empleados.
  */
 function cdb_buscar_empleados_ajax() {
+    if ( ! is_user_logged_in() ) {
+        error_log( 'cdb_buscar_empleados_ajax: usuario no autenticado' );
+        wp_send_json_error( array( 'message' => __( 'Debe iniciar sesión.', 'cdb-form' ) ), 403 );
+    }
     if ( ! check_ajax_referer( 'cdb_form_nonce', 'nonce', false ) ) {
+        error_log( 'cdb_buscar_empleados_ajax: nonce incorrecto' );
         wp_send_json_error( array( 'message' => __( 'Nonce incorrecto', 'cdb-form' ) ) );
     }
 
@@ -382,13 +387,17 @@ function cdb_buscar_empleados_ajax() {
     wp_send_json_success( array( 'html' => $html ) );
 }
 add_action( 'wp_ajax_cdb_buscar_empleados', 'cdb_buscar_empleados_ajax' );
-add_action( 'wp_ajax_nopriv_cdb_buscar_empleados', 'cdb_buscar_empleados_ajax' );
 
 /**
  * Proporciona sugerencias de autocompletado.
  */
 function cdb_busqueda_sugerencias_ajax() {
+    if ( ! is_user_logged_in() ) {
+        error_log( 'cdb_busqueda_sugerencias_ajax: usuario no autenticado' );
+        wp_send_json_error( array( 'message' => __( 'Debe iniciar sesión.', 'cdb-form' ) ), 403 );
+    }
     if ( ! check_ajax_referer( 'cdb_form_nonce', 'nonce', false ) ) {
+        error_log( 'cdb_busqueda_sugerencias_ajax: nonce incorrecto' );
         wp_send_json_error( array( 'message' => __( 'Nonce incorrecto', 'cdb-form' ) ) );
     }
 
@@ -455,4 +464,3 @@ function cdb_busqueda_sugerencias_ajax() {
     wp_send_json( $results );
 }
 add_action( 'wp_ajax_cdb_sugerencias', 'cdb_busqueda_sugerencias_ajax' );
-add_action( 'wp_ajax_nopriv_cdb_sugerencias', 'cdb_busqueda_sugerencias_ajax' );


### PR DESCRIPTION
## Summary
- require authentication and check nonce for employee search and suggestions
- remove public access to those AJAX endpoints
- report AJAX errors in JS

## Testing
- `php -l includes/ajax-functions.php`

------
https://chatgpt.com/codex/tasks/task_e_688d144d4e0883279bfb2168c8295ffd