### PR TITLE
Add bar search shortcode with AJAX

### DIFF
--- a/cdb-form.php
+++ b/cdb-form.php
@@ -123,7 +123,7 @@ function cdb_form_enqueue_scripts_conditionally() {
         $needs_main = true;
     }
 
-    if ( has_shortcode( $post->post_content, 'cdb_busqueda_empleados' ) ) {
+    if ( has_shortcode( $post->post_content, 'cdb_busqueda_empleados' ) || has_shortcode( $post->post_content, 'cdb_busqueda_bares' ) ) {
         wp_enqueue_script(
             'awesomplete',
             'https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.5/awesomplete.min.js',

--- a/templates/busqueda-bares-table.php
+++ b/templates/busqueda-bares-table.php
@@ -1,0 +1,35 @@
+<?php if ( empty( $bares ) ) : ?>
+    <p><?php esc_html_e( 'No se encontraron bares con esos filtros.', 'cdb-form' ); ?></p>
+<?php else : ?>
+<table class="cdb-busqueda-table">
+    <thead>
+        <tr>
+            <th><?php esc_html_e( 'Nombre', 'cdb-form' ); ?></th>
+            <th><?php esc_html_e( 'Zona', 'cdb-form' ); ?></th>
+            <th><?php esc_html_e( 'Año', 'cdb-form' ); ?></th>
+            <th><?php esc_html_e( 'Reputación', 'cdb-form' ); ?></th>
+            <th><?php esc_html_e( 'Equipos', 'cdb-form' ); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach ( $bares as $bar ) : ?>
+        <tr>
+            <td><a href="<?php echo esc_url( get_permalink( $bar['id'] ) ); ?>"><?php echo esc_html( $bar['nombre'] ); ?></a></td>
+            <td>
+                <?php if ( ! empty( $bar['zona'] ) ) : ?>
+                    <a href="<?php echo esc_url( get_permalink( $bar['zona']['id'] ) ); ?>"><?php echo esc_html( $bar['zona']['nombre'] ); ?></a>
+                <?php endif; ?>
+            </td>
+            <td><?php echo esc_html( $bar['apertura'] ); ?></td>
+            <td><?php echo esc_html( $bar['reputacion'] ); ?></td>
+            <td>
+                <?php foreach ( $bar['equipos'] as $i => $eq ) : ?>
+                    <?php if ( $i > 0 ) echo ', '; ?>
+                    <a href="<?php echo esc_url( get_permalink( $eq['id'] ) ); ?>"><?php echo esc_html( $eq['nombre'] ); ?></a>
+                <?php endforeach; ?>
+            </td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+<?php endif; ?>

--- a/templates/busqueda-bares.php
+++ b/templates/busqueda-bares.php
@@ -1,0 +1,31 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<style>
+.cdb-busqueda-filtros{margin-bottom:1em;display:flex;flex-wrap:wrap;gap:10px;align-items:flex-end}
+.cdb-busqueda-filtros input{padding:4px}
+.cdb-btn-filtrar{padding:6px 12px;background:#000;color:#FAF8EE;border:0;border-radius:4px;cursor:pointer}
+.cdb-btn-filtrar:hover{background:#444}
+.cdb-busqueda-table{width:100%;border-collapse:collapse}
+.cdb-busqueda-table th,.cdb-busqueda-table td{padding:6px;border-bottom:1px solid #ccc;text-align:left}
+#cdb-busqueda-bares-spinner{display:none;margin-top:10px}
+#cdb-busqueda-bares .awesomplete > ul{background:#FAF8EE}
+#cdb-busqueda-bares .awesomplete > ul > li[aria-selected="true"]{background:#E6E1D3}
+</style>
+<div id="cdb-busqueda-bares">
+    <div class="cdb-busqueda-filtros">
+        <input type="text" id="cdb-bar-nombre" placeholder="<?php esc_attr_e('Nombre','cdb-form'); ?>" />
+        <input type="text" id="cdb-zona" placeholder="<?php esc_attr_e('Zona','cdb-form'); ?>" />
+        <input type="hidden" id="cdb-zona-id" />
+        <input type="text" id="cdb-apertura" placeholder="<?php esc_attr_e('Año','cdb-form'); ?>" />
+        <input type="text" id="cdb-reputacion" placeholder="<?php esc_attr_e('Reputación','cdb-form'); ?>" />
+        <button id="cdb-bar-filtrar" class="cdb-btn-filtrar" type="button"><?php esc_html_e('Filtrar','cdb-form'); ?></button>
+        <button id="cdb-bar-limpiar" class="cdb-btn-filtrar" type="button"><?php esc_html_e('Limpiar','cdb-form'); ?></button>
+    </div>
+    <div id="cdb-busqueda-bares-resultados">
+        <?php include CDB_FORM_PATH . 'templates/busqueda-bares-table.php'; ?>
+    </div>
+    <div id="cdb-busqueda-bares-spinner"><?php esc_html_e('Cargando...','cdb-form'); ?></div>
+</div>


### PR DESCRIPTION
## Summary
- implement `[cdb_busqueda_bares]` shortcode
- add templates for bar search form and table
- support bar search in AJAX handlers and JS
- enqueue frontend assets when the new shortcode is present

## Testing
- `php -l templates/busqueda-bares.php`
- `php -l templates/busqueda-bares-table.php`
- `php -l includes/shortcodes.php`
- `php -l includes/ajax-functions.php`
- `php -l cdb-form.php`

------
https://chatgpt.com/codex/tasks/task_e_688d37370b6083279f4a1c7b48f4675a