### PR TITLE
Implement updated bar search shortcode with AJAX autocomplete

### DIFF
--- a/assets/js/frontend-scripts.js
+++ b/assets/js/frontend-scripts.js
@@ -244,14 +244,15 @@ jQuery(document).ready(function($) {
         return true;
     }
 
-   var initResult = initBusqueda();
+    var initResult = initBusqueda();
     if (initResult === false) {
         document.addEventListener('awesomplete-loaded', initBusqueda, { once: true });
         setTimeout(initBusqueda, 50);
+        setTimeout(function(){ if(!window.Awesomplete){ console.error('Awesomplete failed to load'); } }, 5000);
     }
 
     // ---- Buscador de bares ----
-    var bNombreInput, zonaInput, zonaIdInput, aperturaInput, repInput;
+    var bNombreInput, zonaInput, zonaIdInput, aperturaInput;
     var filtrarBarBtn, limpiarBarBtn;
 
     function cdbBuscarBares(){
@@ -263,8 +264,7 @@ jQuery(document).ready(function($) {
             nonce: cdb_form_ajax.nonce,
             nombre: bNombreInput.value,
             zona_id: zonaIdInput.value,
-            apertura: aperturaInput.value,
-            reputacion: repInput.value
+            apertura: aperturaInput.value
         };
 
         jQuery.getJSON(cdb_form_ajax.ajaxurl, params, function(resp){
@@ -286,7 +286,6 @@ jQuery(document).ready(function($) {
         zonaInput      = document.getElementById('cdb-zona');
         zonaIdInput    = document.getElementById('cdb-zona-id');
         aperturaInput  = document.getElementById('cdb-apertura');
-        repInput       = document.getElementById('cdb-reputacion');
         filtrarBarBtn  = document.getElementById('cdb-bar-filtrar');
         limpiarBarBtn  = document.getElementById('cdb-bar-limpiar');
 
@@ -311,13 +310,10 @@ jQuery(document).ready(function($) {
                 bNombreInput.value = '';
                 zonaInput.value = '';
                 aperturaInput.value = '';
-                repInput.value = '';
                 zonaIdInput.value = '';
                 bNombreInput.dataset.valid = '';
                 zonaInput.dataset.valid = '';
-                aperturaInput.dataset.valid = '';
-                repInput.dataset.valid = '';
-                cdbBuscarBares();
+            cdbBuscarBares();
             });
         }
 
@@ -332,7 +328,7 @@ jQuery(document).ready(function($) {
             });
         }
 
-        var zonaS = [], barS = [], repS = [];
+        var zonaS = [], barS = [];
 
         var awBarNombre = new Awesomplete(bNombreInput, {minChars:1, autoFirst:true});
         bNombreInput.addEventListener('input', function(){
@@ -355,25 +351,7 @@ jQuery(document).ready(function($) {
             if(obj){ zonaIdInput.value = obj.id; zonaInput.dataset.valid = '1'; }
         });
 
-        var awApertura = new Awesomplete(aperturaInput, {minChars:1, autoFirst:true});
-        aperturaInput.addEventListener('input', function(){
-            aperturaInput.dataset.valid = '';
-            obtenerSugs('apertura', this.value, function(res){ awApertura.list = res.map(function(r){ return r.label; }); });
-        });
-        aperturaInput.addEventListener('awesomplete-selectcomplete', function(){ aperturaInput.dataset.valid = '1'; });
-
-        var awRep = new Awesomplete(repInput, {minChars:1, autoFirst:true});
-        repInput.addEventListener('input', function(){
-            repInput.dataset.valid = '';
-            obtenerSugs('reputacion', this.value, function(res){ repS = res; awRep.list = res.map(function(r){ return r.label; }); });
-        });
-        repInput.addEventListener('awesomplete-selectcomplete', function(){
-            var val = repInput.value;
-            var obj = repS.find(function(i){ return i.label === val; });
-            if(obj){ repInput.dataset.valid = '1'; }
-        });
-
-        [bNombreInput, zonaInput, aperturaInput, repInput].forEach(function(el){
+        [bNombreInput, zonaInput, aperturaInput].forEach(function(el){
             el.addEventListener('keydown', function(e){
                 if(e.key === 'Enter'){ e.preventDefault(); if(filtrarBarBtn) filtrarBarBtn.click(); }
             });
@@ -392,14 +370,6 @@ jQuery(document).ready(function($) {
                 alert('Selecciona una zona válida');
                 return false;
             }
-            if(aperturaInput.value && !aperturaInput.dataset.valid){
-                alert('Selecciona un año válido');
-                return false;
-            }
-            if(repInput.value && !repInput.dataset.valid && !/^[0-9]+(\.[0-9]+)?$/.test(repInput.value)){
-                alert('Reputación inválida');
-                return false;
-            }
             return true;
         }
 
@@ -412,6 +382,7 @@ jQuery(document).ready(function($) {
     if (initBars === false) {
         document.addEventListener('awesomplete-loaded', initBusquedaBares, { once: true });
         setTimeout(initBusquedaBares, 50);
+        setTimeout(function(){ if(!window.Awesomplete){ console.error('Awesomplete failed to load for buscador de bares'); } }, 5000);
     }
 });
 

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -402,10 +402,9 @@ function cdb_buscar_bares_ajax() {
     }
 
     $args = array(
-        'nombre'     => isset( $_GET['nombre'] ) ? sanitize_text_field( $_GET['nombre'] ) : '',
-        'zona_id'    => isset( $_GET['zona_id'] ) ? intval( $_GET['zona_id'] ) : 0,
-        'apertura'   => isset( $_GET['apertura'] ) ? intval( $_GET['apertura'] ) : 0,
-        'reputacion' => isset( $_GET['reputacion'] ) ? sanitize_text_field( $_GET['reputacion'] ) : '',
+        'nombre'   => isset( $_GET['nombre'] ) ? sanitize_text_field( $_GET['nombre'] ) : '',
+        'zona_id'  => isset( $_GET['zona_id'] ) ? intval( $_GET['zona_id'] ) : 0,
+        'apertura' => isset( $_GET['apertura'] ) ? intval( $_GET['apertura'] ) : 0,
     );
 
     $bares = cdb_busqueda_bares_get_datos( $args );

--- a/templates/busqueda-bares-table.php
+++ b/templates/busqueda-bares-table.php
@@ -4,16 +4,16 @@
 <table class="cdb-busqueda-table">
     <thead>
         <tr>
+            <th><?php esc_html_e( 'Puntuación', 'cdb-form' ); ?></th>
             <th><?php esc_html_e( 'Nombre', 'cdb-form' ); ?></th>
             <th><?php esc_html_e( 'Zona', 'cdb-form' ); ?></th>
             <th><?php esc_html_e( 'Año', 'cdb-form' ); ?></th>
-            <th><?php esc_html_e( 'Reputación', 'cdb-form' ); ?></th>
-            <th><?php esc_html_e( 'Equipos', 'cdb-form' ); ?></th>
         </tr>
     </thead>
     <tbody>
     <?php foreach ( $bares as $bar ) : ?>
         <tr>
+            <td><?php echo esc_html( $bar['puntuacion'] ); ?></td>
             <td><a href="<?php echo esc_url( get_permalink( $bar['id'] ) ); ?>"><?php echo esc_html( $bar['nombre'] ); ?></a></td>
             <td>
                 <?php if ( ! empty( $bar['zona'] ) ) : ?>
@@ -21,13 +21,6 @@
                 <?php endif; ?>
             </td>
             <td><?php echo esc_html( $bar['apertura'] ); ?></td>
-            <td><?php echo esc_html( $bar['reputacion'] ); ?></td>
-            <td>
-                <?php foreach ( $bar['equipos'] as $i => $eq ) : ?>
-                    <?php if ( $i > 0 ) echo ', '; ?>
-                    <a href="<?php echo esc_url( get_permalink( $eq['id'] ) ); ?>"><?php echo esc_html( $eq['nombre'] ); ?></a>
-                <?php endforeach; ?>
-            </td>
         </tr>
     <?php endforeach; ?>
     </tbody>

--- a/templates/busqueda-bares.php
+++ b/templates/busqueda-bares.php
@@ -20,7 +20,6 @@ if ( ! defined( 'ABSPATH' ) ) {
         <input type="text" id="cdb-zona" placeholder="<?php esc_attr_e('Zona','cdb-form'); ?>" />
         <input type="hidden" id="cdb-zona-id" />
         <input type="text" id="cdb-apertura" placeholder="<?php esc_attr_e('Año','cdb-form'); ?>" />
-        <input type="text" id="cdb-reputacion" placeholder="<?php esc_attr_e('Reputación','cdb-form'); ?>" />
         <button id="cdb-bar-filtrar" class="cdb-btn-filtrar" type="button"><?php esc_html_e('Filtrar','cdb-form'); ?></button>
         <button id="cdb-bar-limpiar" class="cdb-btn-filtrar" type="button"><?php esc_html_e('Limpiar','cdb-form'); ?></button>
     </div>


### PR DESCRIPTION
## Summary
- refine `[cdb_busqueda_bares]` shortcode
- simplify template filters and table output
- update AJAX handler and JS for new filters
- add error reporting if Awesomplete fails to load

## Testing
- `php -l includes/shortcodes.php`
- `php -l templates/busqueda-bares.php`
- `php -l templates/busqueda-bares-table.php`
- `php -l includes/ajax-functions.php`
- `node --check assets/js/frontend-scripts.js`

------
https://chatgpt.com/codex/tasks/task_e_688d3c755d4c83279525e648d0157191