### PR TITLE
Improve welcome message for new employees

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -164,7 +164,13 @@ function cdb_bienvenida_empleado_shortcode() {
         // Mostrar la Puntuación de Experiencia.
         $output .= '<p><strong>' . esc_html__( 'Puntuación de Experiencia:', 'cdb-form' ) . '</strong> ' . esc_html($puntuacion_experiencia) . '</p>';
     } else {
-        $output .= '<p style="color: red;">' . esc_html__( 'No tienes ningún perfil de empleado asignado.', 'cdb-form' ) . '</p>';
+        $user_name = $current_user->display_name;
+        $output .= '<div class="cdb-bienvenida-empleado">';
+        $output .= '<h2>¡Hola, ' . esc_html( $user_name ) . '!</h2>';
+        $output .= '<p><strong>Bienvenido/a al Proyecto CdB</strong></p>';
+        $output .= '<p>Gracias por unirte a nuestra comunidad de empleados de hostelería.<br>';
+        $output .= '¡Estás a un paso de empezar a construir tu perfil, compartir tu experiencia y conectar con otros profesionales y bares!';
+        $output .= '</p></div>';
         $output .= do_shortcode('[cdb_form_empleado]');
     }
     return $output;
@@ -271,7 +277,20 @@ function cdb_experiencia_shortcode() {
     }
     $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
     if ($empleado_id === 0) {
-        return '<p style="color: red;">' . esc_html__( 'No tienes un perfil de empleado registrado.', 'cdb-form' ) . '</p>';
+        $user_name = $current_user->display_name;
+        ob_start();
+        ?>
+        <div class="cdb-bienvenida-empleado">
+            <h2>¡Hola, <?php echo esc_html( $user_name ); ?>!</h2>
+            <p><strong>Bienvenido/a al Proyecto CdB</strong></p>
+            <p>
+                Gracias por unirte a nuestra comunidad de empleados de hostelería.<br>
+                ¡Estás a un paso de empezar a construir tu perfil, compartir tu experiencia y conectar con otros profesionales y bares!
+            </p>
+        </div>
+        <?php
+        echo do_shortcode('[cdb_form_empleado]');
+        return ob_get_clean();
     }
     ob_start();
     include CDB_FORM_PATH . 'templates/form-experiencia-template.php';

--- a/templates/form-experiencia-template.php
+++ b/templates/form-experiencia-template.php
@@ -14,7 +14,13 @@ if (!$current_user->exists()) {
 // Obtener la ID del empleado asociado al usuario actual mediante la función específica.
 $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
 if (!$empleado_id) {
-    echo '<p>' . esc_html__( 'No tienes un perfil de empleado registrado. Para registrar experiencia, primero debes crear tu perfil de empleado.', 'cdb-form' ) . '</p>';
+    $user_name = $current_user->display_name;
+    echo '<div class="cdb-bienvenida-empleado">';
+    echo '<h2>¡Hola, ' . esc_html( $user_name ) . '!</h2>';
+    echo '<p><strong>Bienvenido/a al Proyecto CdB</strong></p>';
+    echo '<p>Gracias por unirte a nuestra comunidad de empleados de hostelería.<br>';
+    echo '¡Estás a un paso de empezar a construir tu perfil, compartir tu experiencia y conectar con otros profesionales y bares!';
+    echo '</p></div>';
     echo do_shortcode('[cdb_form_empleado]');
     return;
 }


### PR DESCRIPTION
## Summary
- remove old error messages when no employee profile exists
- show a friendly welcome block before the employee creation form

## Testing
- `php -l includes/shortcodes.php`
- `php -l templates/form-experiencia-template.php`

------
https://chatgpt.com/codex/tasks/task_e_688d597187188327a182e8db00eef28a