### PR TITLE
Allow configurable welcome messages for [cdb_bienvenida_usuario] shortcode

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -91,7 +91,6 @@ function cdb_bienvenida_usuario_shortcode() {
     }
     $current_user = wp_get_current_user();
     $output  = '<h1>' . sprintf( esc_html__( '¡Hola, %s!', 'cdb-form' ), esc_html($current_user->display_name) ) . '</h1>';
-    $output .= '<p>' . esc_html__( 'Grácias por colaborar con el Proyecto CdB!', 'cdb-form' ) . '</p>';
 
     $tiene_seccion = false;
     // Cargar la sección de empleado si el usuario tiene ese rol.
@@ -106,13 +105,21 @@ function cdb_bienvenida_usuario_shortcode() {
     }
 
     if (!$tiene_seccion) {
-        // Mensaje y color del aviso del shortcode [cdb_bienvenida_usuario]
-        // Ambos son configurables desde las opciones 'cdb_mensaje_bienvenida_usuario' (mensaje)
-        // y 'cdb_color_bienvenida_usuario' (color/tipo de mensaje, por defecto: 'aviso')
-        // Pensado para futura gestión desde el panel de administración.
+        // Ambos mensajes y colores del shortcode [cdb_bienvenida_usuario] son configurables mediante las opciones:
+        // 'cdb_mensaje_bienvenida_usuario', 'cdb_color_bienvenida_usuario'
+        // 'cdb_mensaje_bienvenida_gracias', 'cdb_color_bienvenida_gracias'
+        // Por defecto: 'No tienes ningún perfil de empleado asignado.' ('aviso'), '¡Gracias por colaborar con el Proyecto CdB!' ('info')
+        // Preparado para futura gestión desde el panel de administración.
         $mensaje = get_option('cdb_mensaje_bienvenida_usuario', 'No tienes ningún perfil de empleado asignado.');
-        $color   = get_option('cdb_color_bienvenida_usuario', 'aviso');
+        $color = get_option('cdb_color_bienvenida_usuario', 'aviso');
+
+        $gracias = get_option('cdb_mensaje_bienvenida_gracias', '¡Gracias por colaborar con el Proyecto CdB!');
+        $color_gracias = get_option('cdb_color_bienvenida_gracias', 'info');
+
+        $output  = '<div class="cdb-aviso cdb-aviso--' . esc_attr($color_gracias) . '">' . esc_html($gracias) . '</div>';
         $output .= '<div class="cdb-aviso cdb-aviso--' . esc_attr($color) . '">' . esc_html($mensaje) . '</div>';
+
+        return $output;
     }
 
     return $output;


### PR DESCRIPTION
## Summary
- Allow customizing both welcome and thank-you messages in `[cdb_bienvenida_usuario]` shortcode
- Support configurable alert types for each message via WordPress options

## Testing
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_688e02144a4c8327a511fc0de5226735