### PR TITLE
feat: add configurable messages submenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Inserta estos shortcodes en una página o entrada para mostrar los distintos for
 - `[cdb_top_empleados_experiencia_precalculada]` – ranking de empleados por puntuación de experiencia.
 - `[cdb_top_empleados_puntuacion_total]` – ranking de empleados por puntuación gráfica.
 
+Los textos y colores mostrados por estos shortcodes pueden personalizarse desde el submenú **Configuración de Mensajes y Avisos** dentro del menú "CdB Form" del panel de administración.
+
 ## Procesamiento de formularios
 
 Los formularios funcionan mediante llamadas AJAX a `admin-ajax.php` y se validan con nonces de seguridad:

--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -1,0 +1,99 @@
+<?php
+// Evitar acceso directo.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Submenú de configuración de mensajes y avisos del plugin CdB Form.
+ *
+ * Este panel centraliza la gestión de los textos y estilos usados
+ * en la experiencia de usuario de CdB. Está preparado para añadidos
+ * futuros mediante una estructura dinámica basada en arrays.
+ */
+function cdb_form_mensajes_admin_menu() {
+    add_submenu_page(
+        'cdb-form',
+        __( 'Configuración de Mensajes y Avisos', 'cdb-form' ),
+        __( 'Configuración de Mensajes y Avisos', 'cdb-form' ),
+        'manage_options',
+        'cdb-form-config-mensajes',
+        'cdb_form_config_mensajes_page'
+    );
+}
+add_action( 'admin_menu', 'cdb_form_mensajes_admin_menu' );
+
+/**
+ * Renderiza la página de opciones y guarda los valores.
+ */
+function cdb_form_config_mensajes_page() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    // Definición de los mensajes configurables.
+    $mensajes = array(
+        'bienvenida_usuario' => array(
+            'text_option'  => 'cdb_mensaje_bienvenida_usuario',
+            'color_option' => 'cdb_color_bienvenida_usuario',
+            'label'        => __( 'Mensaje de Bienvenida (sin perfil)', 'cdb-form' ),
+            'description'  => __( 'Este mensaje se muestra solo a usuarios que aún no han creado perfil de empleado', 'cdb-form' ),
+        ),
+        'bienvenida_gracias' => array(
+            'text_option'  => 'cdb_mensaje_bienvenida_gracias',
+            'color_option' => 'cdb_color_bienvenida_gracias',
+            'label'        => __( 'Mensaje de Agradecimiento', 'cdb-form' ),
+            'description'  => __( 'Texto opcional de agradecimiento mostrado en la bienvenida', 'cdb-form' ),
+        ),
+    );
+
+    $tipos_color = array(
+        'aviso'        => __( 'Aviso', 'cdb-form' ),
+        'info'         => __( 'Info', 'cdb-form' ),
+        'exito'        => __( 'Éxito', 'cdb-form' ),
+        'motivacional' => __( 'Motivacional', 'cdb-form' ),
+    );
+
+    if ( isset( $_POST['cdb_form_config_mensajes_nonce'] ) &&
+         check_admin_referer( 'cdb_form_config_mensajes_save', 'cdb_form_config_mensajes_nonce' ) ) {
+        foreach ( $mensajes as $datos ) {
+            if ( isset( $_POST[ $datos['text_option'] ] ) ) {
+                update_option( $datos['text_option'], wp_kses_post( $_POST[ $datos['text_option'] ] ) );
+            }
+            if ( isset( $_POST[ $datos['color_option'] ] ) ) {
+                update_option( $datos['color_option'], sanitize_text_field( $_POST[ $datos['color_option'] ] ) );
+            }
+        }
+        echo '<div class="updated"><p>' . esc_html__( 'Opciones guardadas.', 'cdb-form' ) . '</p></div>';
+    }
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Configuración de Mensajes y Avisos', 'cdb-form' ); ?></h1>
+        <p><?php esc_html_e( 'Este panel centraliza la gestión de mensajes/avisos de la experiencia de usuario CdB.', 'cdb-form' ); ?></p>
+        <form method="post">
+            <?php wp_nonce_field( 'cdb_form_config_mensajes_save', 'cdb_form_config_mensajes_nonce' ); ?>
+            <table class="form-table" role="presentation">
+                <?php foreach ( $mensajes as $datos ) :
+                    $texto  = get_option( $datos['text_option'], '' );
+                    $color  = get_option( $datos['color_option'], 'aviso' );
+                    ?>
+                    <tr>
+                        <th scope="row"><label for="<?php echo esc_attr( $datos['text_option'] ); ?>"><?php echo esc_html( $datos['label'] ); ?></label></th>
+                        <td>
+                            <textarea class="large-text" rows="3" id="<?php echo esc_attr( $datos['text_option'] ); ?>" name="<?php echo esc_attr( $datos['text_option'] ); ?>"><?php echo esc_textarea( $texto ); ?></textarea>
+                            <p class="description"><?php echo esc_html( $datos['description'] ); ?></p>
+                            <label for="<?php echo esc_attr( $datos['color_option'] ); ?>"><?php esc_html_e( 'Tipo/Color', 'cdb-form' ); ?></label>
+                            <select id="<?php echo esc_attr( $datos['color_option'] ); ?>" name="<?php echo esc_attr( $datos['color_option'] ); ?>">
+                                <?php foreach ( $tipos_color as $valor => $label ) : ?>
+                                    <option value="<?php echo esc_attr( $valor ); ?>" <?php selected( $color, $valor ); ?>><?php echo esc_html( $label ); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+    <?php
+}

--- a/includes/init.php
+++ b/includes/init.php
@@ -22,6 +22,7 @@ require_once CDB_FORM_PATH . 'includes/ajax-functions.php';
 // Cargar scripts y estilos para el admin y frontend
 require_once CDB_FORM_PATH . 'admin/enqueue.php';
 require_once CDB_FORM_PATH . 'admin/diseno-empleado.php';
+require_once CDB_FORM_PATH . 'admin/config-mensajes.php';
 require_once CDB_FORM_PATH . 'public/enqueue.php';
 
 // Acción de inicialización del plugin

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -108,7 +108,10 @@ function cdb_bienvenida_usuario_shortcode() {
 
     // 3) Preparar saludo inicial común para roles relevantes.
     $output  = '<h1>' . sprintf( esc_html__( '¡Hola, %s!', 'cdb-form' ), esc_html($current_user->display_name) ) . '</h1>';
-    $output .= '<p>' . esc_html__( 'Grácias por colaborar con el Proyecto CdB!', 'cdb-form' ) . '</p>';
+    // Mensaje de agradecimiento configurable.
+    $mensaje_gracias = get_option( 'cdb_mensaje_bienvenida_gracias', __( 'Grácias por colaborar con el Proyecto CdB!', 'cdb-form' ) );
+    $color_gracias   = get_option( 'cdb_color_bienvenida_gracias', 'info' );
+    $output         .= '<div class="cdb-aviso cdb-aviso--' . esc_attr( $color_gracias ) . '">' . esc_html( $mensaje_gracias ) . '</div>';
 
     // 4) Lógica específica para empleados.
     if (in_array('empleado', $roles)) {
@@ -119,9 +122,9 @@ function cdb_bienvenida_usuario_shortcode() {
             $output .= do_shortcode('[cdb_bienvenida_empleado]');
         } else {
             // Sin perfil: mensaje configurable e invitación a crear uno.
-            $mensaje = get_option('cdb_mensaje_invitar_empleado', 'No tienes ningún perfil de empleado asignado.');
-            $color   = get_option('cdb_color_invitar_empleado', 'aviso');
-            $output .= '<div class="cdb-aviso cdb-aviso--' . esc_attr($color) . '">' . esc_html($mensaje) . '</div>';
+            $mensaje = get_option( 'cdb_mensaje_bienvenida_usuario', 'No tienes ningún perfil de empleado asignado.' );
+            $color   = get_option( 'cdb_color_bienvenida_usuario', 'aviso' );
+            $output .= '<div class="cdb-aviso cdb-aviso--' . esc_attr( $color ) . '">' . esc_html( $mensaje ) . '</div>';
             $output .= do_shortcode('[cdb_form_empleado]');
         }
     }
@@ -196,9 +199,11 @@ function cdb_bienvenida_empleado_shortcode() {
         $output .= '<p><strong>' . esc_html__( 'Puntuación de Experiencia:', 'cdb-form' ) . '</strong> ' . esc_html($puntuacion_experiencia) . '</p>';
     } else {
         // Mensaje de bienvenida del shortcode [cdb_bienvenida_usuario]
-        // Ahora configurable desde la opción 'cdb_mensaje_bienvenida_usuario' (por defecto: 'No tienes ningún perfil de empleado asignado.')
-        $mensaje = get_option('cdb_mensaje_bienvenida_usuario', 'No tienes ningún perfil de empleado asignado.');
-        $output .= '<div class="cdb-aviso">' . esc_html($mensaje) . '</div>';
+        // Configurable desde las opciones 'cdb_mensaje_bienvenida_usuario' y
+        // 'cdb_color_bienvenida_usuario' (por defecto: 'No tienes ningún perfil de empleado asignado.')
+        $mensaje = get_option( 'cdb_mensaje_bienvenida_usuario', 'No tienes ningún perfil de empleado asignado.' );
+        $color   = get_option( 'cdb_color_bienvenida_usuario', 'aviso' );
+        $output .= '<div class="cdb-aviso cdb-aviso--' . esc_attr( $color ) . '">' . esc_html( $mensaje ) . '</div>';
         $output .= do_shortcode('[cdb_form_empleado]');
     }
     return $output;


### PR DESCRIPTION
## Summary
- add configurable message/color admin submenu for CdB Form
- load custom messages in bienvenida shortcodes
- document new settings in README

## Testing
- `php -l admin/config-mensajes.php`
- `php -l includes/init.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_688e233511d08327a3bf26743e49e4cb