### PR TITLE
feat: enhance message config panel

### DIFF
--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -31,68 +31,134 @@ function cdb_form_config_mensajes_page() {
         return;
     }
 
-    // Definición de los mensajes configurables.
+    // Definición de los mensajes configurables en el orden solicitado.
     $mensajes = array(
-        'bienvenida_usuario' => array(
-            'text_option'  => 'cdb_mensaje_bienvenida_usuario',
-            'color_option' => 'cdb_color_bienvenida_usuario',
-            'label'        => __( 'Mensaje de Bienvenida (sin perfil)', 'cdb-form' ),
-            'description'  => __( 'Este mensaje se muestra solo a usuarios que aún no han creado perfil de empleado', 'cdb-form' ),
-        ),
         'bienvenida_gracias' => array(
             'text_option'  => 'cdb_mensaje_bienvenida_gracias',
             'color_option' => 'cdb_color_bienvenida_gracias',
             'label'        => __( 'Mensaje de Agradecimiento', 'cdb-form' ),
             'description'  => __( 'Texto opcional de agradecimiento mostrado en la bienvenida', 'cdb-form' ),
         ),
+        'bienvenida_usuario' => array(
+            'text_option'  => 'cdb_mensaje_bienvenida_usuario',
+            'color_option' => 'cdb_color_bienvenida_usuario',
+            'label'        => __( 'Mensaje de Bienvenida (sin perfil)', 'cdb-form' ),
+            'description'  => __( 'Este mensaje se muestra solo a usuarios que aún no han creado perfil de empleado', 'cdb-form' ),
+        ),
     );
 
-    $tipos_color = array(
-        'aviso'        => __( 'Aviso', 'cdb-form' ),
-        'info'         => __( 'Info', 'cdb-form' ),
-        'exito'        => __( 'Éxito', 'cdb-form' ),
-        'motivacional' => __( 'Motivacional', 'cdb-form' ),
-    );
+    // Tipos/color disponibles
+    $tipos_color = cdb_form_get_tipos_color();
 
-    if ( isset( $_POST['cdb_form_config_mensajes_nonce'] ) &&
-         check_admin_referer( 'cdb_form_config_mensajes_save', 'cdb_form_config_mensajes_nonce' ) ) {
+    $mensaje_guardado = '';
+    $tipo_mensaje     = 'exito';
+
+    if (
+        isset( $_POST['cdb_form_config_mensajes_nonce'] ) &&
+        check_admin_referer( 'cdb_form_config_mensajes_save', 'cdb_form_config_mensajes_nonce' )
+    ) {
+        // Guardar textos y tipo/color de cada mensaje
         foreach ( $mensajes as $datos ) {
             if ( isset( $_POST[ $datos['text_option'] ] ) ) {
                 update_option( $datos['text_option'], wp_kses_post( $_POST[ $datos['text_option'] ] ) );
             }
             if ( isset( $_POST[ $datos['color_option'] ] ) ) {
-                update_option( $datos['color_option'], sanitize_text_field( $_POST[ $datos['color_option'] ] ) );
+                update_option( $datos['color_option'], sanitize_key( $_POST[ $datos['color_option'] ] ) );
             }
         }
-        echo '<div class="updated"><p>' . esc_html__( 'Opciones guardadas.', 'cdb-form' ) . '</p></div>';
+
+        // Guardar tipos/color
+        $tipos_nuevos   = array();
+        $nombres        = array();
+        $duplicado      = false;
+        if ( isset( $_POST['tipos_color'] ) && is_array( $_POST['tipos_color'] ) ) {
+            foreach ( $_POST['tipos_color'] as $slug => $datos ) {
+                if ( isset( $datos['delete'] ) && '1' === $datos['delete'] ) {
+                    continue; // saltar elementos marcados para borrar
+                }
+                $nombre = sanitize_text_field( $datos['name'] ?? '' );
+                if ( in_array( $nombre, $nombres, true ) ) {
+                    $duplicado = true;
+                    break;
+                }
+                $nombres[] = $nombre;
+                $slug_sanit = sanitize_key( $slug );
+                $tipos_nuevos[ $slug_sanit ] = array(
+                    'name'  => $nombre,
+                    'class' => sanitize_html_class( $datos['class'] ?? '' ),
+                    'color' => sanitize_hex_color( $datos['color'] ?? '' ),
+                );
+            }
+            if ( ! $duplicado ) {
+                update_option( 'cdb_form_tipos_color', $tipos_nuevos );
+                $tipos_color = cdb_form_get_tipos_color(); // refrescar
+            }
+        }
+
+        if ( $duplicado ) {
+            $mensaje_guardado = __( 'No se pudo guardar: nombres de tipo/color duplicados.', 'cdb-form' );
+            $tipo_mensaje     = 'aviso';
+        } else {
+            $mensaje_guardado = __( 'Opciones guardadas.', 'cdb-form' );
+        }
     }
     ?>
     <div class="wrap">
         <h1><?php esc_html_e( 'Configuración de Mensajes y Avisos', 'cdb-form' ); ?></h1>
         <p><?php esc_html_e( 'Este panel centraliza la gestión de mensajes/avisos de la experiencia de usuario CdB.', 'cdb-form' ); ?></p>
+        <?php if ( $mensaje_guardado ) :
+            $clase_notice = cdb_form_get_tipo_color_class( $tipo_mensaje );
+            $color_notice = $tipos_color[ $tipo_mensaje ]['color'] ?? '#000';
+            ?>
+            <div class="cdb-aviso <?php echo esc_attr( $clase_notice ); ?>" style="border-left-color: <?php echo esc_attr( $color_notice ); ?>;">
+                <p><?php echo esc_html( $mensaje_guardado ); ?></p>
+            </div>
+        <?php endif; ?>
         <form method="post">
             <?php wp_nonce_field( 'cdb_form_config_mensajes_save', 'cdb_form_config_mensajes_nonce' ); ?>
-            <table class="form-table" role="presentation">
-                <?php foreach ( $mensajes as $datos ) :
-                    $texto  = get_option( $datos['text_option'], '' );
-                    $color  = get_option( $datos['color_option'], 'aviso' );
-                    ?>
-                    <tr>
-                        <th scope="row"><label for="<?php echo esc_attr( $datos['text_option'] ); ?>"><?php echo esc_html( $datos['label'] ); ?></label></th>
-                        <td>
-                            <textarea class="large-text" rows="3" id="<?php echo esc_attr( $datos['text_option'] ); ?>" name="<?php echo esc_attr( $datos['text_option'] ); ?>"><?php echo esc_textarea( $texto ); ?></textarea>
-                            <p class="description"><?php echo esc_html( $datos['description'] ); ?></p>
-                            <label for="<?php echo esc_attr( $datos['color_option'] ); ?>"><?php esc_html_e( 'Tipo/Color', 'cdb-form' ); ?></label>
-                            <select id="<?php echo esc_attr( $datos['color_option'] ); ?>" name="<?php echo esc_attr( $datos['color_option'] ); ?>">
-                                <?php foreach ( $tipos_color as $valor => $label ) : ?>
-                                    <option value="<?php echo esc_attr( $valor ); ?>" <?php selected( $color, $valor ); ?>><?php echo esc_html( $label ); ?></option>
-                                <?php endforeach; ?>
-                            </select>
-                        </td>
-                    </tr>
+
+            <?php foreach ( $mensajes as $id => $datos ) :
+                $texto      = get_option( $datos['text_option'], '' );
+                $tipo       = get_option( $datos['color_option'], 'aviso' );
+                $datos_tipo = $tipos_color[ $tipo ] ?? array();
+                $clase      = $datos_tipo['class'] ?? '';
+                $color_hex  = $datos_tipo['color'] ?? '#000';
+                ?>
+                <div class="cdb-config-mensaje" id="mensaje-<?php echo esc_attr( $id ); ?>">
+                    <strong><?php echo esc_html( $datos['label'] ); ?></strong>
+                    <div class="cdb-mensaje-preview <?php echo esc_attr( $clase ); ?>" style="border-left-color: <?php echo esc_attr( $color_hex ); ?>;">
+                        <?php echo esc_html( $texto ); ?>
+                    </div>
+                    <button type="button" class="button cdb-edit-mensaje"><?php esc_html_e( 'Editar', 'cdb-form' ); ?></button>
+                    <div class="cdb-mensaje-edicion" style="display:none;">
+                        <textarea class="large-text" rows="3" name="<?php echo esc_attr( $datos['text_option'] ); ?>"><?php echo esc_textarea( $texto ); ?></textarea>
+                        <p class="description"><?php echo esc_html( $datos['description'] ); ?></p>
+                        <label><?php esc_html_e( 'Tipo/Color', 'cdb-form' ); ?></label>
+                        <select name="<?php echo esc_attr( $datos['color_option'] ); ?>">
+                            <?php foreach ( $tipos_color as $slug => $info ) : ?>
+                                <option value="<?php echo esc_attr( $slug ); ?>" data-color="<?php echo esc_attr( $info['color'] ); ?>" data-class="<?php echo esc_attr( $info['class'] ); ?>" style="color: <?php echo esc_attr( $info['color'] ); ?>;" <?php selected( $tipo, $slug ); ?>>&#11044; <?php echo esc_html( $info['name'] ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <p class="description"><?php esc_html_e( 'Clase CSS:', 'cdb-form' ); ?> <code class="cdb-clase-css"><?php echo esc_html( $clase ); ?></code></p>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+
+            <h2><?php esc_html_e( 'Tipos/Colores', 'cdb-form' ); ?></h2>
+            <div id="cdb-tipos-color">
+                <?php foreach ( $tipos_color as $slug => $info ) : ?>
+                    <div class="cdb-tipo-color-row">
+                        <span class="cdb-color-swatch" style="background-color: <?php echo esc_attr( $info['color'] ); ?>"></span>
+                        <input type="text" name="tipos_color[<?php echo esc_attr( $slug ); ?>][name]" value="<?php echo esc_attr( $info['name'] ); ?>" />
+                        <input type="text" name="tipos_color[<?php echo esc_attr( $slug ); ?>][class]" value="<?php echo esc_attr( $info['class'] ); ?>" />
+                        <input type="color" name="tipos_color[<?php echo esc_attr( $slug ); ?>][color]" value="<?php echo esc_attr( $info['color'] ); ?>" />
+                        <label><input type="checkbox" name="tipos_color[<?php echo esc_attr( $slug ); ?>][delete]" value="1" /> <?php esc_html_e( 'Eliminar', 'cdb-form' ); ?></label>
+                    </div>
                 <?php endforeach; ?>
-            </table>
-            <?php submit_button(); ?>
+            </div>
+            <p><button type="button" class="button" id="cdb-add-tipo-color"><?php esc_html_e( 'Añadir tipo/color', 'cdb-form' ); ?></button></p>
+
+            <?php submit_button( __( 'Guardar cambios', 'cdb-form' ) ); ?>
         </form>
     </div>
     <?php

--- a/admin/enqueue.php
+++ b/admin/enqueue.php
@@ -11,9 +11,30 @@ function cdb_form_admin_enqueue( $hook ) {
         return;
     }
 
-    // No se requieren dependencias adicionales en la página de configuración
-    if ( 'toplevel_page_cdb-form-disenio-empleado' === $hook ) {
-        // Se podrían añadir estilos propios aquí en el futuro
+    // Recursos para la configuración de mensajes y avisos
+    if ( 'cdb-form_page_cdb-form-config-mensajes' === $hook ) {
+        wp_enqueue_style(
+            'cdb-form-config-mensajes',
+            CDB_FORM_URL . 'assets/css/config-mensajes.css',
+            array(),
+            '1.0'
+        );
+        wp_enqueue_script(
+            'cdb-form-config-mensajes',
+            CDB_FORM_URL . 'assets/js/config-mensajes.js',
+            array( 'jquery' ),
+            '1.0',
+            true
+        );
+        wp_localize_script(
+            'cdb-form-config-mensajes',
+            'cdbMensajes',
+            array(
+                'nuevoNombre' => __( 'Nombre', 'cdb-form' ),
+                'nuevaClase'  => __( 'Clase CSS', 'cdb-form' ),
+                'eliminar'    => __( 'Eliminar', 'cdb-form' ),
+            )
+        );
     }
 }
 add_action( 'admin_enqueue_scripts', 'cdb_form_admin_enqueue' );

--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -1,0 +1,8 @@
+.cdb-config-mensaje { margin-bottom: 20px; }
+.cdb-config-mensaje.editing { border: 1px solid #2271b1; padding: 10px; }
+.cdb-mensaje-preview { padding: 8px 12px; margin-bottom: 8px; border-left: 4px solid transparent; }
+.cdb-color-swatch { display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:4px; vertical-align:middle; }
+.cdb-tipo-color-row { display:flex; align-items:center; gap:6px; margin-bottom:6px; }
+.cdb-tipo-color-row input[type="text"] { width:120px; }
+.cdb-tipo-color-row .cdb-color-swatch { width:20px; height:20px; }
+.cdb-tipo-color-row.deleting { opacity:0.5; }

--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -1,0 +1,42 @@
+jQuery(document).ready(function($){
+    // Toggle edición de mensaje
+    $('.cdb-edit-mensaje').on('click', function(){
+        var cont = $(this).closest('.cdb-config-mensaje');
+        cont.toggleClass('editing');
+        cont.find('.cdb-mensaje-edicion').toggle();
+    });
+
+    // Actualizar preview de texto
+    $('.cdb-mensaje-edicion textarea').on('input', function(){
+        $(this).closest('.cdb-config-mensaje').find('.cdb-mensaje-preview').text($(this).val());
+    });
+
+    // Actualizar preview de color y clase
+    $('.cdb-mensaje-edicion select').on('change', function(){
+        var opt   = $(this).find('option:selected');
+        var color = opt.data('color');
+        var cls   = opt.data('class');
+        var cont  = $(this).closest('.cdb-config-mensaje');
+        var prev  = cont.find('.cdb-mensaje-preview');
+        prev.removeClass().addClass('cdb-mensaje-preview').addClass(cls);
+        prev.css('border-left-color', color);
+        cont.find('.cdb-clase-css').text(cls);
+    }).trigger('change');
+
+    // Añadir nuevo tipo/color
+    $('#cdb-add-tipo-color').on('click', function(e){
+        e.preventDefault();
+        var idx = $('#cdb-tipos-color .cdb-tipo-color-row').length + 1;
+        var row = $('<div class="cdb-tipo-color-row"></div>');
+        row.append('<input type="text" name="tipos_color[new_'+idx+'][name]" placeholder="'+cdbMensajes.nuevoNombre+'" />');
+        row.append('<input type="text" name="tipos_color[new_'+idx+'][class]" placeholder="'+cdbMensajes.nuevaClase+'" />');
+        row.append('<input type="color" name="tipos_color[new_'+idx+'][color]" value="#000000" />');
+        row.append('<label><input type="checkbox" name="tipos_color[new_'+idx+'][delete]" value="1" /> '+cdbMensajes.eliminar+'</label>');
+        $('#cdb-tipos-color').append(row);
+    });
+
+    // Marcar fila como eliminada
+    $('#cdb-tipos-color').on('change', 'input[type="checkbox"]', function(){
+        $(this).closest('.cdb-tipo-color-row').toggleClass('deleting', this.checked);
+    });
+});

--- a/includes/init.php
+++ b/includes/init.php
@@ -18,6 +18,7 @@ require_once CDB_FORM_PATH . 'includes/validations.php';
 require_once CDB_FORM_PATH . 'includes/capabilities.php';
 require_once CDB_FORM_PATH . 'includes/shortcodes.php';
 require_once CDB_FORM_PATH . 'includes/ajax-functions.php';
+require_once CDB_FORM_PATH . 'includes/messages.php';
 
 // Cargar scripts y estilos para el admin y frontend
 require_once CDB_FORM_PATH . 'admin/enqueue.php';

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -1,0 +1,78 @@
+<?php
+// Evitar acceso directo.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Gestiona los tipos de avisos (nombre, clase y color) del sistema.
+ *
+ * Se usa una opción de WordPress para permitir que el administrador añada,
+ * modifique o elimine tipos de avisos desde el panel. Este sistema está
+ * preparado para escalar a más tipos de avisos en el futuro y puede ser
+ * extendido por otros plugins mediante las funciones aquí definidas.
+ */
+
+/**
+ * Obtiene la lista de tipos de avisos disponibles.
+ *
+ * @return array
+ */
+function cdb_form_get_tipos_color() {
+    $defaults = array(
+        'aviso' => array(
+            'name'  => __( 'Aviso', 'cdb-form' ),
+            'class' => 'cdb-aviso--aviso',
+            'color' => '#dc2626',
+        ),
+        'info' => array(
+            'name'  => __( 'Info', 'cdb-form' ),
+            'class' => 'cdb-aviso--info',
+            'color' => '#2563eb',
+        ),
+        'exito' => array(
+            'name'  => __( 'Éxito', 'cdb-form' ),
+            'class' => 'cdb-aviso--exito',
+            'color' => '#16a34a',
+        ),
+    );
+
+    $stored = get_option( 'cdb_form_tipos_color', array() );
+    if ( empty( $stored ) || ! is_array( $stored ) ) {
+        $stored = $defaults;
+    }
+
+    return $stored;
+}
+
+/**
+ * Devuelve la clase CSS de un tipo de aviso.
+ *
+ * @param string $slug Identificador del tipo.
+ * @return string
+ */
+function cdb_form_get_tipo_color_class( $slug ) {
+    $tipos = cdb_form_get_tipos_color();
+    return isset( $tipos[ $slug ] ) ? $tipos[ $slug ]['class'] : '';
+}
+
+/**
+ * Registra programáticamente un nuevo tipo de aviso.
+ *
+ * @param string $slug  Identificador único.
+ * @param array  $args  {name, class, color}
+ */
+function cdb_form_register_tipo_color( $slug, $args ) {
+    $tipos = cdb_form_get_tipos_color();
+    $slug  = sanitize_key( $slug );
+
+    $tipos[ $slug ] = wp_parse_args(
+        array(
+            'name'  => isset( $args['name'] ) ? sanitize_text_field( $args['name'] ) : $slug,
+            'class' => isset( $args['class'] ) ? sanitize_html_class( $args['class'] ) : 'cdb-aviso--' . $slug,
+            'color' => isset( $args['color'] ) ? sanitize_hex_color( $args['color'] ) : '#000000',
+        )
+    );
+
+    update_option( 'cdb_form_tipos_color', $tipos );
+}

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -110,8 +110,9 @@ function cdb_bienvenida_usuario_shortcode() {
     $output  = '<h1>' . sprintf( esc_html__( '¡Hola, %s!', 'cdb-form' ), esc_html($current_user->display_name) ) . '</h1>';
     // Mensaje de agradecimiento configurable.
     $mensaje_gracias = get_option( 'cdb_mensaje_bienvenida_gracias', __( 'Grácias por colaborar con el Proyecto CdB!', 'cdb-form' ) );
-    $color_gracias   = get_option( 'cdb_color_bienvenida_gracias', 'info' );
-    $output         .= '<div class="cdb-aviso cdb-aviso--' . esc_attr( $color_gracias ) . '">' . esc_html( $mensaje_gracias ) . '</div>';
+    $tipo_gracias    = get_option( 'cdb_color_bienvenida_gracias', 'info' );
+    $clase_gracias   = cdb_form_get_tipo_color_class( $tipo_gracias );
+    $output         .= '<div class="cdb-aviso ' . esc_attr( $clase_gracias ) . '">' . esc_html( $mensaje_gracias ) . '</div>';
 
     // 4) Lógica específica para empleados.
     if (in_array('empleado', $roles)) {
@@ -122,9 +123,10 @@ function cdb_bienvenida_usuario_shortcode() {
             $output .= do_shortcode('[cdb_bienvenida_empleado]');
         } else {
             // Sin perfil: mensaje configurable e invitación a crear uno.
-            $mensaje = get_option( 'cdb_mensaje_bienvenida_usuario', 'No tienes ningún perfil de empleado asignado.' );
-            $color   = get_option( 'cdb_color_bienvenida_usuario', 'aviso' );
-            $output .= '<div class="cdb-aviso cdb-aviso--' . esc_attr( $color ) . '">' . esc_html( $mensaje ) . '</div>';
+            $mensaje       = get_option( 'cdb_mensaje_bienvenida_usuario', 'No tienes ningún perfil de empleado asignado.' );
+            $tipo_usuario  = get_option( 'cdb_color_bienvenida_usuario', 'aviso' );
+            $clase_usuario = cdb_form_get_tipo_color_class( $tipo_usuario );
+            $output       .= '<div class="cdb-aviso ' . esc_attr( $clase_usuario ) . '">' . esc_html( $mensaje ) . '</div>';
             $output .= do_shortcode('[cdb_form_empleado]');
         }
     }
@@ -201,9 +203,10 @@ function cdb_bienvenida_empleado_shortcode() {
         // Mensaje de bienvenida del shortcode [cdb_bienvenida_usuario]
         // Configurable desde las opciones 'cdb_mensaje_bienvenida_usuario' y
         // 'cdb_color_bienvenida_usuario' (por defecto: 'No tienes ningún perfil de empleado asignado.')
-        $mensaje = get_option( 'cdb_mensaje_bienvenida_usuario', 'No tienes ningún perfil de empleado asignado.' );
-        $color   = get_option( 'cdb_color_bienvenida_usuario', 'aviso' );
-        $output .= '<div class="cdb-aviso cdb-aviso--' . esc_attr( $color ) . '">' . esc_html( $mensaje ) . '</div>';
+        $mensaje    = get_option( 'cdb_mensaje_bienvenida_usuario', 'No tienes ningún perfil de empleado asignado.' );
+        $tipo_color = get_option( 'cdb_color_bienvenida_usuario', 'aviso' );
+        $clase      = cdb_form_get_tipo_color_class( $tipo_color );
+        $output    .= '<div class="cdb-aviso ' . esc_attr( $clase ) . '">' . esc_html( $mensaje ) . '</div>';
         $output .= do_shortcode('[cdb_form_empleado]');
     }
     return $output;


### PR DESCRIPTION
## Summary
- add dynamic color/type registry and utilities
- allow editing/previewing messages and managing types in admin panel
- load admin assets for live preview of message styles

## Testing
- `php -l includes/messages.php`
- `php -l includes/init.php`
- `php -l includes/shortcodes.php`
- `php -l admin/enqueue.php`
- `php -l admin/config-mensajes.php`


------
https://chatgpt.com/codex/tasks/task_e_688e28ddedb883279c9dfb89356fc47c