### PR TITLE
Load message configuration styles on frontend

### DIFF
--- a/admin/enqueue.php
+++ b/admin/enqueue.php
@@ -4,7 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-// Cargar estilos y scripts en el panel de administración
+// Cargar estilos y scripts en el panel de administración.
+// La hoja de estilos "config-mensajes.css" se comparte con el frontend
+// (ver public/enqueue.php) para que las clases de aviso definidas en la
+// configuración tengan estilo también para los usuarios.
 function cdb_form_admin_enqueue( $hook ) {
     // Cargar solo en las páginas del plugin
     if ( strpos( $hook, 'cdb-form' ) === false ) {

--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -1,3 +1,18 @@
+/*!
+ * Estilos base para los avisos y su configuración.
+ *
+ * Esta hoja se carga tanto en el administrador como en el frontend. Proporciona
+ * la estructura principal de los mensajes (<div class="cdb-aviso">) mientras que
+ * los colores específicos de cada tipo se añaden dinámicamente desde
+ * public/enqueue.php mediante <code>wp_add_inline_style</code>.
+ */
+.cdb-aviso {
+    padding: 8px 12px;
+    margin-bottom: 8px;
+    border-left: 4px solid transparent;
+}
+
+/* Estilos utilizados únicamente en la pantalla de Configuración de Mensajes */
 .cdb-config-mensaje { margin-bottom: 20px; }
 .cdb-config-mensaje.editing { border: 1px solid #2271b1; padding: 10px; }
 .cdb-mensaje-preview { padding: 8px 12px; margin-bottom: 8px; border-left: 4px solid transparent; }

--- a/public/enqueue.php
+++ b/public/enqueue.php
@@ -4,9 +4,18 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-// Cargar estilos y scripts en el frontend
+/**
+ * Encola los recursos necesarios en el frontal del sitio.
+ *
+ * Además del script principal (registrado para cargarse solo cuando se
+ * necesite), aquí se encola la hoja de estilos base para los mensajes y se
+ * generan reglas dinámicas para cada tipo/color configurable por el
+ * administrador.  De esta forma, los shortcodes que imprimen avisos pueden
+ * usar clases como <code>cdb-aviso--aviso</code> o cualquier otra definida en
+ * la pantalla de ajustes y mantener los colores elegidos.
+ */
 function cdb_form_public_enqueue() {
-    // Registrar el script sin encolarlo
+    // Registrar el script sin encolarlo; se encolará condicionalmente.
     wp_register_script(
         'cdb-form-frontend-script',
         CDB_FORM_URL . 'assets/js/frontend-scripts.js',
@@ -15,7 +24,31 @@ function cdb_form_public_enqueue() {
         true
     );
 
-    // Pasar AJAX URL y Nonce a JavaScript
+    // Hoja de estilos compartida entre el admin y el frontend.
+    wp_enqueue_style(
+        'cdb-form-config-mensajes',
+        CDB_FORM_URL . 'assets/css/config-mensajes.css',
+        array(),
+        '1.0'
+    );
+
+    // Generar las reglas CSS para cada tipo/color definido.
+    $tipos = cdb_form_get_tipos_color();
+    $css   = '';
+    foreach ( $tipos as $info ) {
+        $class = isset( $info['class'] ) ? sanitize_html_class( $info['class'] ) : '';
+        $color = isset( $info['color'] ) ? sanitize_hex_color( $info['color'] ) : '';
+        if ( ! $class || ! $color ) {
+            continue;
+        }
+        $css .= sprintf( '.%1$s{border-left-color:%2$s;}', $class, $color );
+    }
+
+    if ( $css ) {
+        wp_add_inline_style( 'cdb-form-config-mensajes', $css );
+    }
+
+    // Pasar AJAX URL y Nonce a JavaScript.
     wp_localize_script( 'cdb-form-frontend-script', 'cdb_form_ajax', array(
         'ajaxurl' => admin_url( 'admin-ajax.php' ),
         'nonce'   => wp_create_nonce( 'cdb_form_nonce' ), // Agregamos el nonce


### PR DESCRIPTION
## Summary
- share `config-mensajes.css` between admin and frontend
- generate inline CSS rules for each custom message type
- document how color styles are handled

## Testing
- `php -l admin/enqueue.php`
- `php -l public/enqueue.php`
- `php /tmp/test_inline.php`

------
https://chatgpt.com/codex/tasks/task_e_688e36f8fb448327bbfcb03803764847