### PR TITLE
feat: allow customizing message text colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ Inserta estos shortcodes en una página o entrada para mostrar los distintos for
 - `[cdb_top_empleados_experiencia_precalculada]` – ranking de empleados por puntuación de experiencia.
 - `[cdb_top_empleados_puntuacion_total]` – ranking de empleados por puntuación gráfica.
 
-Los textos y colores mostrados por estos shortcodes pueden personalizarse desde el submenú **Configuración de Mensajes y Avisos** dentro del menú "CdB Form" del panel de administración.
+ Los textos y los colores de fondo y texto mostrados por estos shortcodes pueden personalizarse desde el submenú **Configuración de Mensajes y Avisos** dentro del menú "CdB Form" del panel de administración.
+
+### Configuración de mensajes y avisos
+
+En esta pantalla es posible editar el contenido de cada mensaje y definir variantes de avisos con sus propias clases CSS. Cada variante permite elegir un color de fondo y otro de texto. Si no se especifica color de texto, el sistema calcula automáticamente uno con contraste adecuado.
+
+Para añadir una nueva variante introduce nombre, clase CSS, color de fondo y color de texto. Posteriormente podrás usar esa variante en los shortcodes seleccionándola en los mensajes correspondientes.
+
+También puedes registrar variantes desde código utilizando `cdb_form_register_tipo_color( $slug, $args )`, pasando un array con `name`, `class`, `color` y `text`.
 
 ## Procesamiento de formularios
 

--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -87,6 +87,7 @@ function cdb_form_config_mensajes_page() {
                     'name'  => $nombre,
                     'class' => sanitize_html_class( $datos['class'] ?? '' ),
                     'color' => sanitize_hex_color( $datos['color'] ?? '' ),
+                    'text'  => sanitize_hex_color( $datos['text'] ?? '' ),
                 );
             }
             if ( ! $duplicado ) {
@@ -108,9 +109,10 @@ function cdb_form_config_mensajes_page() {
         <p><?php esc_html_e( 'Este panel centraliza la gestión de mensajes/avisos de la experiencia de usuario CdB.', 'cdb-form' ); ?></p>
         <?php if ( $mensaje_guardado ) :
             $clase_notice = cdb_form_get_tipo_color_class( $tipo_mensaje );
-            $color_notice = $tipos_color[ $tipo_mensaje ]['color'] ?? '#000';
+            $bg_notice    = $tipos_color[ $tipo_mensaje ]['color'] ?? '#000';
+            $text_notice  = $tipos_color[ $tipo_mensaje ]['text'] ?? cdb_form_get_contrasting_text_color( $bg_notice );
             ?>
-            <div class="cdb-aviso <?php echo esc_attr( $clase_notice ); ?>" style="border-left-color: <?php echo esc_attr( $color_notice ); ?>;">
+            <div class="cdb-aviso <?php echo esc_attr( $clase_notice ); ?>" style="border-left-color: <?php echo esc_attr( $bg_notice ); ?>; background-color: <?php echo esc_attr( $bg_notice ); ?>; color: <?php echo esc_attr( $text_notice ); ?>;">
                 <p><?php echo esc_html( $mensaje_guardado ); ?></p>
             </div>
         <?php endif; ?>
@@ -123,10 +125,11 @@ function cdb_form_config_mensajes_page() {
                 $datos_tipo = $tipos_color[ $tipo ] ?? array();
                 $clase      = $datos_tipo['class'] ?? '';
                 $color_hex  = $datos_tipo['color'] ?? '#000';
+                $text_hex   = $datos_tipo['text'] ?? cdb_form_get_contrasting_text_color( $color_hex );
                 ?>
                 <div class="cdb-config-mensaje" id="mensaje-<?php echo esc_attr( $id ); ?>">
                     <strong><?php echo esc_html( $datos['label'] ); ?></strong>
-                    <div class="cdb-mensaje-preview <?php echo esc_attr( $clase ); ?>" style="border-left-color: <?php echo esc_attr( $color_hex ); ?>;">
+                    <div class="cdb-mensaje-preview <?php echo esc_attr( $clase ); ?>" style="border-left-color: <?php echo esc_attr( $color_hex ); ?>; background-color: <?php echo esc_attr( $color_hex ); ?>; color: <?php echo esc_attr( $text_hex ); ?>;">
                         <?php echo esc_html( $texto ); ?>
                     </div>
                     <button type="button" class="button cdb-edit-mensaje"><?php esc_html_e( 'Editar', 'cdb-form' ); ?></button>
@@ -136,7 +139,7 @@ function cdb_form_config_mensajes_page() {
                         <label><?php esc_html_e( 'Tipo/Color', 'cdb-form' ); ?></label>
                         <select name="<?php echo esc_attr( $datos['color_option'] ); ?>">
                             <?php foreach ( $tipos_color as $slug => $info ) : ?>
-                                <option value="<?php echo esc_attr( $slug ); ?>" data-color="<?php echo esc_attr( $info['color'] ); ?>" data-class="<?php echo esc_attr( $info['class'] ); ?>" style="color: <?php echo esc_attr( $info['color'] ); ?>;" <?php selected( $tipo, $slug ); ?>>&#11044; <?php echo esc_html( $info['name'] ); ?></option>
+                                <option value="<?php echo esc_attr( $slug ); ?>" data-color="<?php echo esc_attr( $info['color'] ); ?>" data-text="<?php echo esc_attr( $info['text'] ); ?>" data-class="<?php echo esc_attr( $info['class'] ); ?>" style="color: <?php echo esc_attr( $info['color'] ); ?>;" <?php selected( $tipo, $slug ); ?>>&#11044; <?php echo esc_html( $info['name'] ); ?></option>
                             <?php endforeach; ?>
                         </select>
                         <p class="description"><?php esc_html_e( 'Clase CSS:', 'cdb-form' ); ?> <code class="cdb-clase-css"><?php echo esc_html( $clase ); ?></code></p>
@@ -145,6 +148,7 @@ function cdb_form_config_mensajes_page() {
             <?php endforeach; ?>
 
             <h2><?php esc_html_e( 'Tipos/Colores', 'cdb-form' ); ?></h2>
+            <p class="description"><?php esc_html_e( 'Selecciona colores de fondo y texto con suficiente contraste para garantizar la legibilidad.', 'cdb-form' ); ?></p>
             <div id="cdb-tipos-color">
                 <?php foreach ( $tipos_color as $slug => $info ) : ?>
                     <div class="cdb-tipo-color-row">
@@ -152,7 +156,8 @@ function cdb_form_config_mensajes_page() {
                         <input type="text" name="tipos_color[<?php echo esc_attr( $slug ); ?>][name]" value="<?php echo esc_attr( $info['name'] ); ?>" />
                         <input type="text" name="tipos_color[<?php echo esc_attr( $slug ); ?>][class]" value="<?php echo esc_attr( $info['class'] ); ?>" />
                         <input type="color" name="tipos_color[<?php echo esc_attr( $slug ); ?>][color]" value="<?php echo esc_attr( $info['color'] ); ?>" />
-                        <label><input type="checkbox" name="tipos_color[<?php echo esc_attr( $slug ); ?>][delete]" value="1" /> <?php esc_html_e( 'Eliminar', 'cdb-form' ); ?></label>
+                        <input type="color" name="tipos_color[<?php echo esc_attr( $slug ); ?>][text]" value="<?php echo esc_attr( $info['text'] ); ?>" />
+                        <label><input type="checkbox" name="tipos_color[<?php echo esc_attr( $slug ); ?>][delete]" value="1" /><?php esc_html_e( 'Eliminar', 'cdb-form' ); ?></label>
                     </div>
                 <?php endforeach; ?>
             </div>

--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -3,8 +3,8 @@
  *
  * Esta hoja se carga tanto en el administrador como en el frontend. Proporciona
  * la estructura principal de los mensajes (<div class="cdb-aviso">) mientras que
- * los colores específicos de cada tipo se añaden dinámicamente desde
- * public/enqueue.php mediante <code>wp_add_inline_style</code>.
+ * los colores específicos de cada tipo (fondo y texto) se añaden dinámicamente
+ * desde public/enqueue.php mediante <code>wp_add_inline_style</code>.
  */
 .cdb-aviso {
     padding: 8px 12px;

--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -11,15 +11,20 @@ jQuery(document).ready(function($){
         $(this).closest('.cdb-config-mensaje').find('.cdb-mensaje-preview').text($(this).val());
     });
 
-    // Actualizar preview de color y clase
+    // Actualizar preview de colores y clase
     $('.cdb-mensaje-edicion select').on('change', function(){
         var opt   = $(this).find('option:selected');
         var color = opt.data('color');
+        var texto = opt.data('text');
         var cls   = opt.data('class');
         var cont  = $(this).closest('.cdb-config-mensaje');
         var prev  = cont.find('.cdb-mensaje-preview');
         prev.removeClass().addClass('cdb-mensaje-preview').addClass(cls);
-        prev.css('border-left-color', color);
+        prev.css({
+            'border-left-color': color,
+            'background-color': color,
+            'color': texto
+        });
         cont.find('.cdb-clase-css').text(cls);
     }).trigger('change');
 
@@ -31,6 +36,7 @@ jQuery(document).ready(function($){
         row.append('<input type="text" name="tipos_color[new_'+idx+'][name]" placeholder="'+cdbMensajes.nuevoNombre+'" />');
         row.append('<input type="text" name="tipos_color[new_'+idx+'][class]" placeholder="'+cdbMensajes.nuevaClase+'" />');
         row.append('<input type="color" name="tipos_color[new_'+idx+'][color]" value="#000000" />');
+        row.append('<input type="color" name="tipos_color[new_'+idx+'][text]" value="#ffffff" />');
         row.append('<label><input type="checkbox" name="tipos_color[new_'+idx+'][delete]" value="1" /> '+cdbMensajes.eliminar+'</label>');
         $('#cdb-tipos-color').append(row);
     });

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -5,12 +5,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Gestiona los tipos de avisos (nombre, clase y color) del sistema.
+ * Gestiona los tipos de avisos (nombre, clase y colores) del sistema.
  *
  * Se usa una opción de WordPress para permitir que el administrador añada,
  * modifique o elimine tipos de avisos desde el panel. Este sistema está
  * preparado para escalar a más tipos de avisos en el futuro y puede ser
  * extendido por otros plugins mediante las funciones aquí definidas.
+ *
+ * A partir de la versión 1.1 los tipos de aviso pueden definir tanto color
+ * de fondo como color de texto. Los valores antiguos que sólo almacenaban el
+ * color de fondo siguen siendo compatibles y se les asignará un color de
+ * texto recomendado automáticamente.
  */
 
 /**
@@ -24,16 +29,19 @@ function cdb_form_get_tipos_color() {
             'name'  => __( 'Aviso', 'cdb-form' ),
             'class' => 'cdb-aviso--aviso',
             'color' => '#dc2626',
+            'text'  => '#ffffff',
         ),
         'info' => array(
             'name'  => __( 'Info', 'cdb-form' ),
             'class' => 'cdb-aviso--info',
             'color' => '#2563eb',
+            'text'  => '#ffffff',
         ),
         'exito' => array(
             'name'  => __( 'Éxito', 'cdb-form' ),
             'class' => 'cdb-aviso--exito',
             'color' => '#16a34a',
+            'text'  => '#ffffff',
         ),
     );
 
@@ -42,7 +50,37 @@ function cdb_form_get_tipos_color() {
         $stored = $defaults;
     }
 
+    // Asegurar claves y compatibilidad con versiones anteriores.
+    foreach ( $stored as $slug => $info ) {
+        if ( empty( $info['color'] ) && isset( $defaults[ $slug ]['color'] ) ) {
+            $info['color'] = $defaults[ $slug ]['color'];
+        }
+        if ( empty( $info['text'] ) ) {
+            $bg          = $info['color'] ?? '#000000';
+            $info['text'] = cdb_form_get_contrasting_text_color( $bg );
+        }
+        $stored[ $slug ] = $info;
+    }
+
     return $stored;
+}
+
+/**
+ * Calcula un color de texto (negro/blanco) legible sobre un color de fondo.
+ *
+ * @param string $hex Color de fondo en formato hexadecimal.
+ * @return string Color de texto recomendado.
+ */
+function cdb_form_get_contrasting_text_color( $hex ) {
+    $hex = ltrim( $hex, '#' );
+    if ( strlen( $hex ) === 3 ) {
+        $hex = preg_replace( '/(.)/', '$1$1', $hex );
+    }
+    $r = hexdec( substr( $hex, 0, 2 ) );
+    $g = hexdec( substr( $hex, 2, 2 ) );
+    $b = hexdec( substr( $hex, 4, 2 ) );
+    $luminance = ( $r * 299 + $g * 587 + $b * 114 ) / 1000;
+    return ( $luminance > 128 ) ? '#000000' : '#ffffff';
 }
 
 /**
@@ -60,7 +98,7 @@ function cdb_form_get_tipo_color_class( $slug ) {
  * Registra programáticamente un nuevo tipo de aviso.
  *
  * @param string $slug  Identificador único.
- * @param array  $args  {name, class, color}
+ * @param array  $args  {name, class, color, text}
  */
 function cdb_form_register_tipo_color( $slug, $args ) {
     $tipos = cdb_form_get_tipos_color();
@@ -71,6 +109,7 @@ function cdb_form_register_tipo_color( $slug, $args ) {
             'name'  => isset( $args['name'] ) ? sanitize_text_field( $args['name'] ) : $slug,
             'class' => isset( $args['class'] ) ? sanitize_html_class( $args['class'] ) : 'cdb-aviso--' . $slug,
             'color' => isset( $args['color'] ) ? sanitize_hex_color( $args['color'] ) : '#000000',
+            'text'  => isset( $args['text'] ) ? sanitize_hex_color( $args['text'] ) : cdb_form_get_contrasting_text_color( $args['color'] ?? '#000000' ),
         )
     );
 

--- a/public/enqueue.php
+++ b/public/enqueue.php
@@ -10,9 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Además del script principal (registrado para cargarse solo cuando se
  * necesite), aquí se encola la hoja de estilos base para los mensajes y se
  * generan reglas dinámicas para cada tipo/color configurable por el
- * administrador.  De esta forma, los shortcodes que imprimen avisos pueden
- * usar clases como <code>cdb-aviso--aviso</code> o cualquier otra definida en
- * la pantalla de ajustes y mantener los colores elegidos.
+ * administrador. A partir de la versión 1.1 estas reglas incluyen tanto el
+ * color de fondo como el de texto, de modo que los shortcodes que imprimen
+ * avisos pueden usar clases como <code>cdb-aviso--aviso</code> o cualquier
+ * otra definida en la pantalla de ajustes y mantener los colores elegidos.
  */
 function cdb_form_public_enqueue() {
     // Registrar el script sin encolarlo; se encolará condicionalmente.
@@ -37,11 +38,15 @@ function cdb_form_public_enqueue() {
     $css   = '';
     foreach ( $tipos as $info ) {
         $class = isset( $info['class'] ) ? sanitize_html_class( $info['class'] ) : '';
-        $color = isset( $info['color'] ) ? sanitize_hex_color( $info['color'] ) : '';
-        if ( ! $class || ! $color ) {
+        $bg    = isset( $info['color'] ) ? sanitize_hex_color( $info['color'] ) : '';
+        $text  = isset( $info['text'] ) ? sanitize_hex_color( $info['text'] ) : '';
+        if ( ! $class || ! $bg ) {
             continue;
         }
-        $css .= sprintf( '.%1$s{border-left-color:%2$s;}', $class, $color );
+        if ( ! $text ) {
+            $text = cdb_form_get_contrasting_text_color( $bg );
+        }
+        $css .= sprintf( '.%1$s{border-left-color:%2$s;background-color:%2$s;color:%3$s;}', $class, $bg, $text );
     }
 
     if ( $css ) {


### PR DESCRIPTION
## Summary
- allow configuring message background and text colors
- add dynamic CSS and admin preview for both colors
- document how to define new message types

## Testing
- `php -l includes/messages.php`
- `php -l public/enqueue.php`
- `php -l admin/config-mensajes.php`


------
https://chatgpt.com/codex/tasks/task_e_688e3ae4cf148327a6a5b419a244dc38