### PR TITLE
feat: unify user greetings and contextual messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Inserta estos shortcodes en una página o entrada para mostrar los distintos for
 - `[cdb_form_bar]` – formulario para crear o editar un bar asociado al usuario.
 - `[cdb_form_empleado]` – formulario para crear o actualizar el perfil de empleado.
 - `[cdb_experiencia]` – formulario de experiencia laboral con listado de entradas guardadas.
-- `[cdb_bienvenida_usuario]` – mensaje de bienvenida que carga distintas secciones según el rol: muestra panel de empleado, empleador o invitación a crear perfil si falta, todo ello con mensajes configurables.
+- `[cdb_bienvenida_usuario]` – muestra siempre un saludo y un mensaje de bienvenida para cualquier usuario autenticado y, según su rol, carga el panel de empleado o empleador. Incluye mensajes específicos para empleados sin perfil o sin experiencia.
 - `[cdb_top_empleados_experiencia_precalculada]` – ranking de empleados por puntuación de experiencia.
 - `[cdb_top_empleados_puntuacion_total]` – ranking de empleados por puntuación gráfica.
 
@@ -32,7 +32,7 @@ Inserta estos shortcodes en una página o entrada para mostrar los distintos for
 
 ### Configuración de mensajes y avisos
 
-En esta pantalla es posible editar el contenido de cada mensaje y definir variantes de avisos con sus propias clases CSS. Cada variante permite elegir un color de fondo y otro de texto. Si no se especifica color de texto, el sistema calcula automáticamente uno con contraste adecuado.
+En esta pantalla es posible editar el contenido de cada mensaje y definir variantes de avisos con sus propias clases CSS. Actualmente pueden configurarse el **Saludo al Usuario**, el **Mensaje de Bienvenida**, el **Mensaje para Empleado sin perfil** y el **Mensaje para Empleado sin experiencia**. Cada variante permite elegir un color de fondo y otro de texto. Si no se especifica color de texto, el sistema calcula automáticamente uno con contraste adecuado.
 
 Para añadir una nueva variante introduce nombre, clase CSS, color de fondo y color de texto. Posteriormente podrás usar esa variante en los shortcodes seleccionándola en los mensajes correspondientes.
 

--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -33,17 +33,29 @@ function cdb_form_config_mensajes_page() {
 
     // Definición de los mensajes configurables en el orden solicitado.
     $mensajes = array(
-        'bienvenida_gracias' => array(
-            'text_option'  => 'cdb_mensaje_bienvenida_gracias',
-            'color_option' => 'cdb_color_bienvenida_gracias',
-            'label'        => __( 'Mensaje de Agradecimiento', 'cdb-form' ),
-            'description'  => __( 'Texto opcional de agradecimiento mostrado en la bienvenida', 'cdb-form' ),
+        'saludo_usuario' => array(
+            'text_option'  => 'cdb_mensaje_saludo_usuario',
+            'color_option' => 'cdb_color_saludo_usuario',
+            'label'        => __( 'Saludo al Usuario', 'cdb-form' ),
+            'description'  => __( 'Texto de saludo inicial. Usa %s para incluir el nombre del usuario.', 'cdb-form' ),
         ),
-        'bienvenida_usuario' => array(
+        'bienvenida_general' => array(
+            'text_option'  => 'cdb_mensaje_bienvenida',
+            'color_option' => 'cdb_color_bienvenida',
+            'label'        => __( 'Mensaje de Bienvenida', 'cdb-form' ),
+            'description'  => __( 'Texto mostrado tras el saludo inicial.', 'cdb-form' ),
+        ),
+        'empleado_sin_perfil' => array(
             'text_option'  => 'cdb_mensaje_bienvenida_usuario',
             'color_option' => 'cdb_color_bienvenida_usuario',
-            'label'        => __( 'Mensaje de Bienvenida (sin perfil)', 'cdb-form' ),
-            'description'  => __( 'Este mensaje se muestra solo a usuarios que aún no han creado perfil de empleado', 'cdb-form' ),
+            'label'        => __( 'Mensaje para Empleado sin perfil', 'cdb-form' ),
+            'description'  => __( 'Se muestra a empleados que aún no han creado su perfil.', 'cdb-form' ),
+        ),
+        'empleado_sin_experiencia' => array(
+            'text_option'  => 'cdb_mensaje_empleado_sin_experiencia',
+            'color_option' => 'cdb_color_empleado_sin_experiencia',
+            'label'        => __( 'Mensaje para Empleado sin experiencia', 'cdb-form' ),
+            'description'  => __( 'Se muestra a empleados con perfil pero sin experiencia registrada.', 'cdb-form' ),
         ),
     );
 


### PR DESCRIPTION
## Summary
- show configurable greeting and welcome message for any logged user
- add employee context messages for missing profile or experience
- document new message options and shortcode behaviour

## Testing
- `php -l admin/config-mensajes.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_688e42bee4448327811b06146423b3dc