### PR TITLE
Fix greeting not configurable and refine messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Inserta estos shortcodes en una página o entrada para mostrar los distintos for
 - `[cdb_top_empleados_experiencia_precalculada]` – ranking de empleados por puntuación de experiencia.
 - `[cdb_top_empleados_puntuacion_total]` – ranking de empleados por puntuación gráfica.
 
- Los textos y los colores de fondo y texto mostrados por estos shortcodes pueden personalizarse desde el submenú **Configuración de Mensajes y Avisos** dentro del menú "CdB Form" del panel de administración.
+Los mensajes y sus colores de fondo y texto mostrados por estos shortcodes pueden personalizarse desde el submenú **Configuración de Mensajes y Avisos** dentro del menú "CdB Form" del panel de administración. El saludo mostrado por `[cdb_bienvenida_usuario]` es fijo y funciona como título de página.
 
 ### Configuración de mensajes y avisos
 
-En esta pantalla es posible editar el contenido de cada mensaje y definir variantes de avisos con sus propias clases CSS. Actualmente pueden configurarse el **Saludo al Usuario**, el **Mensaje de Bienvenida**, el **Mensaje para Empleado sin perfil** y el **Mensaje para Empleado sin experiencia**. Cada variante permite elegir un color de fondo y otro de texto. Si no se especifica color de texto, el sistema calcula automáticamente uno con contraste adecuado.
+En esta pantalla es posible editar el contenido de cada mensaje y definir variantes de avisos con sus propias clases CSS. Actualmente pueden configurarse el **Mensaje de Bienvenida**, el **Mensaje para Empleado sin perfil** y el **Mensaje para Empleado sin experiencia**. Cada variante permite elegir un color de fondo y otro de texto. Si no se especifica color de texto, el sistema calcula automáticamente uno con contraste adecuado.
 
 Para añadir una nueva variante introduce nombre, clase CSS, color de fondo y color de texto. Posteriormente podrás usar esa variante en los shortcodes seleccionándola en los mensajes correspondientes.
 

--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -31,14 +31,8 @@ function cdb_form_config_mensajes_page() {
         return;
     }
 
-    // Definición de los mensajes configurables en el orden solicitado.
+    // Definición de los mensajes configurables.
     $mensajes = array(
-        'saludo_usuario' => array(
-            'text_option'  => 'cdb_mensaje_saludo_usuario',
-            'color_option' => 'cdb_color_saludo_usuario',
-            'label'        => __( 'Saludo al Usuario', 'cdb-form' ),
-            'description'  => __( 'Texto de saludo inicial. Usa %s para incluir el nombre del usuario.', 'cdb-form' ),
-        ),
         'bienvenida_general' => array(
             'text_option'  => 'cdb_mensaje_bienvenida',
             'color_option' => 'cdb_color_bienvenida',

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -85,8 +85,8 @@ function cdb_calcular_puntuacion_experiencia_dinamica($empleado_id) {
  * Shortcode [cdb_bienvenida_usuario]
  *
  * Centraliza la lógica de visibilidad y carga secciones específicas según el rol
- * del usuario. Siempre muestra un saludo y un mensaje de bienvenida
- * configurables para cualquier usuario autenticado.
+ * del usuario. Muestra siempre un saludo (no configurable) y un mensaje de
+ * bienvenida configurable para cualquier usuario autenticado.
  *  - Empleado sin perfil: muestra mensaje configurable e invita a crear uno.
  *  - Empleado con perfil pero sin experiencia: muestra mensaje configurable.
  *  - Empleado con perfil y experiencia: muestra su panel de bienvenida.
@@ -106,12 +106,10 @@ function cdb_bienvenida_usuario_shortcode() {
     // 3) Saludo y mensaje de bienvenida comunes a todos los usuarios.
     $output = '';
 
-    $saludo_template = get_option( 'cdb_mensaje_saludo_usuario', __( '¡Hola, %s!', 'cdb-form' ) );
-    $tipo_saludo     = get_option( 'cdb_color_saludo_usuario', 'info' );
-    $clase_saludo    = cdb_form_get_tipo_color_class( $tipo_saludo );
-    $output         .= '<div class="cdb-aviso ' . esc_attr( $clase_saludo ) . '"><h1>' .
-        sprintf( esc_html( $saludo_template ), esc_html( $current_user->display_name ) ) . '</h1></div>';
+    // Saludo fijo como título de la página, no forma parte de los mensajes configurables.
+    $output .= '<h1>' . sprintf( esc_html__( '¡Hola, %s!', 'cdb-form' ), esc_html( $current_user->display_name ) ) . '</h1>';
 
+    // Mensaje de bienvenida configurable.
     $mensaje_bienvenida = get_option( 'cdb_mensaje_bienvenida', __( 'Gracias por colaborar con el Proyecto CdB.', 'cdb-form' ) );
     $tipo_bienvenida    = get_option( 'cdb_color_bienvenida', 'info' );
     $clase_bienvenida   = cdb_form_get_tipo_color_class( $tipo_bienvenida );


### PR DESCRIPTION
## Summary
- Present user greeting as fixed page title outside colored notice blocks
- Remove greeting options from message configuration admin page
- Update docs to note greeting is not configurable

## Testing
- `php -l includes/shortcodes.php`
- `php -l admin/config-mensajes.php`


------
https://chatgpt.com/codex/tasks/task_e_688e47ea71588327b4f633c6e387e681