### PR TITLE
feat: centralize user messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,19 @@ Inserta estos shortcodes en una página o entrada para mostrar los distintos for
 - `[cdb_top_empleados_experiencia_precalculada]` – ranking de empleados por puntuación de experiencia.
 - `[cdb_top_empleados_puntuacion_total]` – ranking de empleados por puntuación gráfica.
 
-Los mensajes y sus colores de fondo y texto mostrados por estos shortcodes pueden personalizarse desde el submenú **Configuración de Mensajes y Avisos** dentro del menú "CdB Form" del panel de administración. El saludo mostrado por `[cdb_bienvenida_usuario]` es fijo y funciona como título de página.
+Los avisos, errores e instrucciones mostrados por estos shortcodes pueden personalizarse desde el submenú **Configuración de Mensajes y Avisos** dentro del menú "CdB Form" del panel de administración. El saludo mostrado por `[cdb_bienvenida_usuario]` es fijo y funciona como título de página.
 
 ### Configuración de mensajes y avisos
 
-En esta pantalla es posible editar el contenido de cada mensaje y definir variantes de avisos con sus propias clases CSS. Actualmente pueden configurarse el **Mensaje de Bienvenida**, el **Mensaje para Empleado sin perfil** y el **Mensaje para Empleado sin experiencia**. Cada variante permite elegir un color de fondo y otro de texto. Si no se especifica color de texto, el sistema calcula automáticamente uno con contraste adecuado.
+En esta pantalla es posible editar el contenido de cada mensaje y definir variantes de avisos con sus propias clases CSS. Además de los mensajes de bienvenida iniciales, es posible configurar avisos como:
+
+- Acceso restringido para usuarios no autenticados.
+- Empleado sin perfil o sin experiencia registrada.
+- Listados de empleados o bares sin resultados.
+- Puntuaciones o posiciones no disponibles.
+- Mensajes de error por falta de permisos o recursos vinculados al usuario (por ejemplo, bar sin registrar).
+
+Cada variante permite elegir un color de fondo y otro de texto. Si no se especifica color de texto, el sistema calcula automáticamente uno con contraste adecuado.
 
 Para añadir una nueva variante introduce nombre, clase CSS, color de fondo y color de texto. Posteriormente podrás usar esa variante en los shortcodes seleccionándola en los mensajes correspondientes.
 

--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -51,7 +51,87 @@ function cdb_form_config_mensajes_page() {
             'label'        => __( 'Mensaje para Empleado sin experiencia', 'cdb-form' ),
             'description'  => __( 'Se muestra a empleados con perfil pero sin experiencia registrada.', 'cdb-form' ),
         ),
+        'login_requerido' => array(
+            'text_option'  => 'cdb_mensaje_login_requerido',
+            'color_option' => 'cdb_color_login_requerido',
+            'label'        => __( 'Acceso restringido sin inicio de sesión', 'cdb-form' ),
+            'description'  => __( 'Se muestra a usuarios no autenticados.', 'cdb-form' ),
+        ),
+        'empleado_no_encontrado' => array(
+            'text_option'  => 'cdb_mensaje_empleado_no_encontrado',
+            'color_option' => 'cdb_color_empleado_no_encontrado',
+            'label'        => __( 'Empleado no encontrado', 'cdb-form' ),
+            'description'  => __( 'Aparece cuando no existe un empleado asociado al usuario.', 'cdb-form' ),
+        ),
+        'puntuacion_no_disponible' => array(
+            'text_option'  => 'cdb_mensaje_puntuacion_no_disponible',
+            'color_option' => 'cdb_color_puntuacion_no_disponible',
+            'label'        => __( 'Puntuación no disponible', 'cdb-form' ),
+            'description'  => __( 'Se muestra cuando no hay puntuación gráfica registrada.', 'cdb-form' ),
+        ),
+        'sin_empleados' => array(
+            'text_option'  => 'cdb_mensaje_sin_empleados',
+            'color_option' => 'cdb_color_sin_empleados',
+            'label'        => __( 'Listado de empleados vacío', 'cdb-form' ),
+            'description'  => __( 'Se muestra cuando un listado de empleados no tiene resultados.', 'cdb-form' ),
+        ),
+        'busqueda_sin_bares' => array(
+            'text_option'  => 'cdb_mensaje_busqueda_sin_bares',
+            'color_option' => 'cdb_color_busqueda_sin_bares',
+            'label'        => __( 'Búsqueda de bares sin resultados', 'cdb-form' ),
+            'description'  => __( 'Se muestra cuando la búsqueda de bares no devuelve resultados.', 'cdb-form' ),
+        ),
+        'busqueda_sin_empleados' => array(
+            'text_option'  => 'cdb_mensaje_busqueda_sin_empleados',
+            'color_option' => 'cdb_color_busqueda_sin_empleados',
+            'label'        => __( 'Búsqueda de empleados sin resultados', 'cdb-form' ),
+            'description'  => __( 'Se muestra cuando la búsqueda de empleados no devuelve resultados.', 'cdb-form' ),
+        ),
+        'experiencia_sin_perfil' => array(
+            'text_option'  => 'cdb_mensaje_experiencia_sin_perfil',
+            'color_option' => 'cdb_color_experiencia_sin_perfil',
+            'label'        => __( 'Experiencia sin perfil', 'cdb-form' ),
+            'description'  => __( 'Aparece en el formulario de experiencia cuando falta el perfil de empleado.', 'cdb-form' ),
+        ),
+        'posicion_no_valida' => array(
+            'text_option'  => 'cdb_mensaje_posicion_no_valida',
+            'color_option' => 'cdb_color_posicion_no_valida',
+            'label'        => __( 'Posición no válida', 'cdb-form' ),
+            'description'  => __( 'Se muestra cuando falta una posición al listar empleados por posición.', 'cdb-form' ),
+        ),
+        'bar_sin_registro' => array(
+            'text_option'  => 'cdb_mensaje_bar_sin_registro',
+            'color_option' => 'cdb_color_bar_sin_registro',
+            'label'        => __( 'Usuario sin bar registrado', 'cdb-form' ),
+            'description'  => __( 'Se muestra cuando el usuario intenta actualizar un bar sin tener uno asignado.', 'cdb-form' ),
+        ),
+        'sin_permiso' => array(
+            'text_option'  => 'cdb_mensaje_sin_permiso',
+            'color_option' => 'cdb_color_sin_permiso',
+            'label'        => __( 'Acceso sin permisos', 'cdb-form' ),
+            'description'  => __( 'Se muestra cuando el usuario no tiene permisos para acceder a la sección.', 'cdb-form' ),
+        ),
+        'disponibilidad_sin_perfil' => array(
+            'text_option'  => 'cdb_mensaje_disponibilidad_sin_perfil',
+            'color_option' => 'cdb_color_disponibilidad_sin_perfil',
+            'label'        => __( 'Disponibilidad sin perfil', 'cdb-form' ),
+            'description'  => __( 'Aparece al actualizar disponibilidad sin tener perfil de empleado.', 'cdb-form' ),
+        ),
     );
+
+    // Ejemplos de futuros mensajes que podrían añadirse:
+    // 'exito_guardado' => array(
+    //     'text_option'  => 'cdb_mensaje_exito_guardado',
+    //     'color_option' => 'cdb_color_exito_guardado',
+    //     'label'        => __( 'Acción completada con éxito', 'cdb-form' ),
+    //     'description'  => __( 'Útil para confirmar guardados o actualizaciones.', 'cdb-form' ),
+    // ),
+    // 'listado_vacio_motivacional' => array(
+    //     'text_option'  => 'cdb_mensaje_listado_vacio',
+    //     'color_option' => 'cdb_color_listado_vacio',
+    //     'label'        => __( 'Listado vacío motivacional', 'cdb-form' ),
+    //     'description'  => __( 'Mensajes positivos cuando un listado no tiene entradas.', 'cdb-form' ),
+    // ),
 
     // Tipos/color disponibles
     $tipos_color = cdb_form_get_tipos_color();

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -115,3 +115,20 @@ function cdb_form_register_tipo_color( $slug, $args ) {
 
     update_option( 'cdb_form_tipos_color', $tipos );
 }
+
+/**
+ * Renderiza un mensaje configurado desde las opciones del plugin.
+ *
+ * @param string $text_option  Nombre de la opción que almacena el texto.
+ * @param string $color_option Nombre de la opción que almacena el tipo/color.
+ * @param string $default_text Texto por defecto si no hay opción guardada.
+ * @param string $default_tipo Tipo/color por defecto.
+ * @return string HTML del mensaje listo para mostrarse.
+ */
+function cdb_form_render_mensaje( $text_option, $color_option, $default_text, $default_tipo = 'aviso' ) {
+    $texto = get_option( $text_option, $default_text );
+    $tipo  = get_option( $color_option, $default_tipo );
+    $clase = cdb_form_get_tipo_color_class( $tipo );
+
+    return '<div class="cdb-aviso ' . esc_attr( $clase ) . '">' . esc_html( $texto ) . '</div>';
+}

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -96,7 +96,11 @@ function cdb_bienvenida_usuario_shortcode() {
     // [cdb_bienvenida_usuario]
     // 1) Comprobación de sesión.
     if (!is_user_logged_in()) {
-        return '<p style="color: red;">' . esc_html__( 'Debes iniciar sesión para acceder a esta página.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_login_requerido',
+            'cdb_color_login_requerido',
+            __( 'Debes iniciar sesión para acceder a esta página.', 'cdb-form' )
+        );
     }
 
     // 2) Preparar datos de usuario y roles.
@@ -323,7 +327,11 @@ function cdb_experiencia_shortcode() {
 
     // 1) Comprobar sesión iniciada; si no la hay, se muestra aviso y se detiene.
     if (!is_user_logged_in()) {
-        return '<p style="color: red;">' . esc_html__( 'Debes iniciar sesión para acceder a esta página.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_login_requerido',
+            'cdb_color_login_requerido',
+            __( 'Debes iniciar sesión para acceder a esta página.', 'cdb-form' )
+        );
     }
 
     // 2) Verificar que el usuario tenga el rol adecuado.
@@ -338,7 +346,11 @@ function cdb_experiencia_shortcode() {
     // La plantilla incluida volverá a validar este dato, generando comprobación redundante.
     $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
     if ($empleado_id === 0) {
-        return '<p style="color: red;">' . esc_html__( 'No tienes un perfil de empleado registrado.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_experiencia_sin_perfil',
+            'cdb_color_experiencia_sin_perfil',
+            __( 'No tienes un perfil de empleado registrado.', 'cdb-form' )
+        );
     }
 
     // 4) Si pasa las verificaciones, se carga la plantilla del formulario.
@@ -395,7 +407,11 @@ add_shortcode('cdb_form_bar', 'cdb_form_bar_shortcode');
  */
 function cdb_mostrar_puntuacion_total() {
     if (!is_user_logged_in()) {
-        return '<p>' . esc_html__( 'Error: Debes iniciar sesión para ver tu puntuación.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_login_requerido',
+            'cdb_color_login_requerido',
+            __( 'Debes iniciar sesión para ver tu puntuación.', 'cdb-form' )
+        );
     }
     $current_user = wp_get_current_user();
     if (!in_array('empleado', (array) $current_user->roles)) {
@@ -403,11 +419,20 @@ function cdb_mostrar_puntuacion_total() {
     }
     $empleado_id = cdb_obtener_empleado_id($current_user->ID);
     if (!$empleado_id) {
-        return '<p>' . esc_html__( 'No se encontró un empleado asociado a este usuario.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_empleado_no_encontrado',
+            'cdb_color_empleado_no_encontrado',
+            __( 'No se encontró un empleado asociado a este usuario.', 'cdb-form' )
+        );
     }
     $puntuacion_total = get_post_meta($empleado_id, 'cdb_puntuacion_total', true);
     if (!$puntuacion_total) {
-        return '<p>' . esc_html__( 'Puntuación Gráfica no disponible.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_puntuacion_no_disponible',
+            'cdb_color_puntuacion_no_disponible',
+            __( 'Puntuación Gráfica no disponible.', 'cdb-form' ),
+            'info'
+        );
     }
     return '<p><strong>' . esc_html__( 'Puntuación Gráfica:', 'cdb-form' ) . '</strong> ' . esc_html($puntuacion_total) . '</p>';
 }
@@ -456,7 +481,11 @@ function cdb_top_empleados_experiencia_precalculada_shortcode() {
 
     // 5) Si no hay empleados, avisar
     if (!$query->have_posts()) {
-        return '<p>' . esc_html__( 'No se encontraron empleados.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_sin_empleados',
+            'cdb_color_sin_empleados',
+            __( 'No se encontraron empleados.', 'cdb-form' )
+        );
     }
 
     // 6) Generar la tabla
@@ -556,7 +585,11 @@ function cdb_top_empleados_puntuacion_total_shortcode() {
 
     // 5) Si no hay empleados, salimos.
     if (!$query->have_posts()) {
-        return '<p>' . esc_html__( 'No se encontraron empleados con puntuación total.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_sin_empleados',
+            'cdb_color_sin_empleados',
+            __( 'No se encontraron empleados con puntuación total.', 'cdb-form' )
+        );
     }
 
     // 6) Cabecera de la tabla
@@ -637,7 +670,11 @@ function cdb_posiciones_empleados_shortcode($atts) {
 
     // Validación: si no hay posicion_id válido, salimos
     if (!$posicion_id) {
-        return '<p style="color: red;">Error: No se ha proporcionado una posición válida.</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_posicion_no_valida',
+            'cdb_color_posicion_no_valida',
+            __( 'Error: No se ha proporcionado una posición válida.', 'cdb-form' )
+        );
     }
 
     // 2) Recuperar el nombre (título) de la Posición
@@ -807,7 +844,11 @@ function cdb_top_bares_puntuacion_total_shortcode() {
     $query = new WP_Query($args);
 
     if (!$query->have_posts()) {
-        return '<p>No se encontraron bares con puntuación total.</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_busqueda_sin_bares',
+            'cdb_color_busqueda_sin_bares',
+            __( 'No se encontraron bares con puntuación total.', 'cdb-form' )
+        );
     }
 
     $output  = '<h3>Top 21 Bares por Puntuación Total (Gráfica)</h3>';
@@ -863,7 +904,11 @@ function cdb_top_bares_gmaps_shortcode() {
     $query = new WP_Query($args);
 
     if (!$query->have_posts()) {
-        return '<p>No se encontraron bares con reputación (gmaps).</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_busqueda_sin_bares',
+            'cdb_color_busqueda_sin_bares',
+            __( 'No se encontraron bares con reputación (gmaps).', 'cdb-form' )
+        );
     }
 
     $output  = '<h3>Top 21 Bares por valoración en Google Maps</h3>';
@@ -919,7 +964,11 @@ function cdb_top_bares_tripadvisor_shortcode() {
     $query = new WP_Query($args);
 
     if (!$query->have_posts()) {
-        return '<p>No se encontraron bares con reputación (tripadvisor).</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_busqueda_sin_bares',
+            'cdb_color_busqueda_sin_bares',
+            __( 'No se encontraron bares con reputación (tripadvisor).', 'cdb-form' )
+        );
     }
 
     $output  = '<h3>Top 21 Bares por valoración en TripAdvisor</h3>';
@@ -975,7 +1024,11 @@ function cdb_top_bares_instagram_shortcode() {
     $query = new WP_Query($args);
 
     if (!$query->have_posts()) {
-        return '<p>No se encontraron bares con reputación (instagram).</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_busqueda_sin_bares',
+            'cdb_color_busqueda_sin_bares',
+            __( 'No se encontraron bares con reputación (instagram).', 'cdb-form' )
+        );
     }
 
     $output  = '<h3>Top 21 Bares por seguidores en Instagram</h3>';

--- a/public/form-bar.php
+++ b/public/form-bar.php
@@ -12,7 +12,11 @@ add_shortcode( 'form-bar', 'cdb_form_bar' );
 function cdb_form_bar() {
     // Comprobar si el usuario está conectado.
     if ( ! is_user_logged_in() ) {
-        return '<p>' . esc_html__( 'Debes iniciar sesión para actualizar el estado de tu bar.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_login_requerido',
+            'cdb_color_login_requerido',
+            __( 'Debes iniciar sesión para actualizar el estado de tu bar.', 'cdb-form' )
+        );
     }
 
     // Obtener el ID del usuario actual.
@@ -26,7 +30,11 @@ function cdb_form_bar() {
     ));
 
     if (empty($bar)) {
-        return '<p>' . esc_html__( 'No tienes un bar registrado. Crea uno antes de actualizar su estado.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_bar_sin_registro',
+            'cdb_color_bar_sin_registro',
+            __( 'No tienes un bar registrado. Crea uno antes de actualizar su estado.', 'cdb-form' )
+        );
     }
 
     $bar_id = $bar[0]->ID;

--- a/public/form-empleado.php
+++ b/public/form-empleado.php
@@ -24,12 +24,20 @@ function cdb_usuario_es_empleado() {
 function cdb_form_empleado() {
     // Comprobar si el usuario está conectado.
     if ( ! is_user_logged_in() ) {
-        return '<p style="color: red;">' . esc_html__( 'Debes iniciar sesión para actualizar tu estado.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_login_requerido',
+            'cdb_color_login_requerido',
+            __( 'Debes iniciar sesión para actualizar tu estado.', 'cdb-form' )
+        );
     }
 
     // Comprobar si el usuario tiene el rol "Empleado".
     if ( ! cdb_usuario_es_empleado() ) {
-        return '<p style="color: red;">' . esc_html__( 'No tienes permisos para acceder a esta sección.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_sin_permiso',
+            'cdb_color_sin_permiso',
+            __( 'No tienes permisos para acceder a esta sección.', 'cdb-form' )
+        );
     }
 
     // Obtener el ID del usuario actual.
@@ -43,7 +51,11 @@ function cdb_form_empleado() {
     ]);
 
     if (empty($empleado)) {
-        return '<p style="color: red;">' . esc_html__( 'No tienes un perfil de empleado. Crea uno antes de actualizar tu disponibilidad.', 'cdb-form' ) . '</p>';
+        return cdb_form_render_mensaje(
+            'cdb_mensaje_disponibilidad_sin_perfil',
+            'cdb_color_disponibilidad_sin_perfil',
+            __( 'No tienes un perfil de empleado. Crea uno antes de actualizar tu disponibilidad.', 'cdb-form' )
+        );
     }
 
     $empleado_id = $empleado[0]->ID;

--- a/templates/busqueda-bares-table.php
+++ b/templates/busqueda-bares-table.php
@@ -1,5 +1,9 @@
 <?php if ( empty( $bares ) ) : ?>
-    <p><?php esc_html_e( 'No se encontraron bares con esos filtros.', 'cdb-form' ); ?></p>
+    <?php echo cdb_form_render_mensaje(
+        'cdb_mensaje_busqueda_sin_bares',
+        'cdb_color_busqueda_sin_bares',
+        __( 'No se encontraron bares con esos filtros.', 'cdb-form' )
+    ); ?>
 <?php else : ?>
 <table class="cdb-busqueda-table">
     <thead>

--- a/templates/busqueda-empleados-table.php
+++ b/templates/busqueda-empleados-table.php
@@ -1,5 +1,9 @@
 <?php if ( empty( $empleados ) ) : ?>
-    <p><?php esc_html_e( 'No se encontraron empleados con esos filtros.', 'cdb-form' ); ?></p>
+    <?php echo cdb_form_render_mensaje(
+        'cdb_mensaje_busqueda_sin_empleados',
+        'cdb_color_busqueda_sin_empleados',
+        __( 'No se encontraron empleados con esos filtros.', 'cdb-form' )
+    ); ?>
 <?php else : ?>
 <table class="cdb-busqueda-table">
     <thead>

--- a/templates/form-empleado-template.php
+++ b/templates/form-empleado-template.php
@@ -7,7 +7,11 @@ if (!defined('ABSPATH')) {
 // Verificar si el usuario está conectado
 $current_user = wp_get_current_user();
 if (!$current_user->exists()) {
-    echo '<p>' . esc_html__( 'Debes iniciar sesión para gestionar tu empleado.', 'cdb-form' ) . '</p>';
+    echo cdb_form_render_mensaje(
+        'cdb_mensaje_login_requerido',
+        'cdb_color_login_requerido',
+        __( 'Debes iniciar sesión para gestionar tu empleado.', 'cdb-form' )
+    );
     return;
 }
 

--- a/templates/form-experiencia-template.php
+++ b/templates/form-experiencia-template.php
@@ -7,14 +7,22 @@ if (!defined('ABSPATH')) {
 // Verificar si el usuario está conectado.
 $current_user = wp_get_current_user();
 if (!$current_user->exists()) {
-    echo '<p>' . esc_html__( 'Debes iniciar sesión para gestionar tu empleado.', 'cdb-form' ) . '</p>';
+    echo cdb_form_render_mensaje(
+        'cdb_mensaje_login_requerido',
+        'cdb_color_login_requerido',
+        __( 'Debes iniciar sesión para gestionar tu empleado.', 'cdb-form' )
+    );
     return;
 }
 
 // Obtener la ID del empleado asociado al usuario actual mediante la función específica.
 $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
 if (!$empleado_id) {
-    echo '<p>' . esc_html__( 'No tienes un perfil de empleado registrado. Para registrar experiencia, primero debes crear tu perfil de empleado.', 'cdb-form' ) . '</p>';
+    echo cdb_form_render_mensaje(
+        'cdb_mensaje_experiencia_sin_perfil',
+        'cdb_color_experiencia_sin_perfil',
+        __( 'No tienes un perfil de empleado registrado. Para registrar experiencia, primero debes crear tu perfil de empleado.', 'cdb-form' )
+    );
     echo do_shortcode('[cdb_form_empleado]');
     return;
 }
@@ -190,7 +198,11 @@ error_log("[DEBUG] Bar ID: {$bar_id_actual} - Apertura: {$fecha_apertura} - Cier
             </tbody>
         </table>
     <?php else : ?>
-        <p><?php esc_html_e( 'No tienes experiencia registrada aún.', 'cdb-form' ); ?></p>
+        <?php echo cdb_form_render_mensaje(
+            'cdb_mensaje_empleado_sin_experiencia',
+            'cdb_color_empleado_sin_experiencia',
+            __( 'Aún no has registrado ninguna experiencia laboral.', 'cdb-form' )
+        ); ?>
     <?php endif; ?>
 </div>
 


### PR DESCRIPTION
## Summary
- add utility to render configurable messages
- register configurable notices for login, missing profiles, empty results and more
- refactor shortcodes/templates to use admin-managed texts

## Testing
- `php -l includes/messages.php`
- `php -l admin/config-mensajes.php`
- `php -l includes/shortcodes.php`
- `php -l templates/form-experiencia-template.php`
- `php -l templates/form-empleado-template.php`
- `php -l templates/busqueda-empleados-table.php`
- `php -l templates/busqueda-bares-table.php`
- `php -l public/form-bar.php`
- `php -l public/form-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_688e4afcc50c8327862568048c9c8aa3