### PR TITLE
feat: allow secondary message lines

### DIFF
--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -143,10 +143,15 @@ function cdb_form_config_mensajes_page() {
         isset( $_POST['cdb_form_config_mensajes_nonce'] ) &&
         check_admin_referer( 'cdb_form_config_mensajes_save', 'cdb_form_config_mensajes_nonce' )
     ) {
-        // Guardar textos y tipo/color de cada mensaje
+        // Guardar textos (principal y secundario) y tipo/color de cada mensaje
         foreach ( $mensajes as $datos ) {
+            $sec_opt = $datos['text_option'] . '_secundaria';
+
             if ( isset( $_POST[ $datos['text_option'] ] ) ) {
                 update_option( $datos['text_option'], wp_kses_post( $_POST[ $datos['text_option'] ] ) );
+            }
+            if ( isset( $_POST[ $sec_opt ] ) ) {
+                update_option( $sec_opt, wp_kses_post( $_POST[ $sec_opt ] ) );
             }
             if ( isset( $_POST[ $datos['color_option'] ] ) ) {
                 update_option( $datos['color_option'], sanitize_key( $_POST[ $datos['color_option'] ] ) );
@@ -206,21 +211,27 @@ function cdb_form_config_mensajes_page() {
             <?php wp_nonce_field( 'cdb_form_config_mensajes_save', 'cdb_form_config_mensajes_nonce' ); ?>
 
             <?php foreach ( $mensajes as $id => $datos ) :
-                $texto      = get_option( $datos['text_option'], '' );
-                $tipo       = get_option( $datos['color_option'], 'aviso' );
-                $datos_tipo = $tipos_color[ $tipo ] ?? array();
-                $clase      = $datos_tipo['class'] ?? '';
-                $color_hex  = $datos_tipo['color'] ?? '#000';
-                $text_hex   = $datos_tipo['text'] ?? cdb_form_get_contrasting_text_color( $color_hex );
+                $texto       = get_option( $datos['text_option'], '' );
+                $sec_opt     = $datos['text_option'] . '_secundaria';
+                $secundario  = get_option( $sec_opt, '' );
+                $tipo        = get_option( $datos['color_option'], 'aviso' );
+                $datos_tipo  = $tipos_color[ $tipo ] ?? array();
+                $clase       = $datos_tipo['class'] ?? '';
+                $color_hex   = $datos_tipo['color'] ?? '#000';
+                $text_hex    = $datos_tipo['text'] ?? cdb_form_get_contrasting_text_color( $color_hex );
                 ?>
                 <div class="cdb-config-mensaje" id="mensaje-<?php echo esc_attr( $id ); ?>">
                     <strong><?php echo esc_html( $datos['label'] ); ?></strong>
                     <div class="cdb-mensaje-preview <?php echo esc_attr( $clase ); ?>" style="border-left-color: <?php echo esc_attr( $color_hex ); ?>; background-color: <?php echo esc_attr( $color_hex ); ?>; color: <?php echo esc_attr( $text_hex ); ?>;">
-                        <?php echo esc_html( $texto ); ?>
+                        <strong class="cdb-mensaje-destacado"><?php echo wp_kses_post( $texto ); ?></strong>
+                        <span class="cdb-mensaje-secundario" <?php if ( empty( $secundario ) ) echo 'style="display:none;"'; ?>><?php echo wp_kses_post( $secundario ); ?></span>
                     </div>
                     <button type="button" class="button cdb-edit-mensaje"><?php esc_html_e( 'Editar', 'cdb-form' ); ?></button>
                     <div class="cdb-mensaje-edicion" style="display:none;">
-                        <textarea class="large-text" rows="3" name="<?php echo esc_attr( $datos['text_option'] ); ?>"><?php echo esc_textarea( $texto ); ?></textarea>
+                        <label><?php esc_html_e( 'Frase destacada', 'cdb-form' ); ?></label>
+                        <textarea class="large-text" rows="2" name="<?php echo esc_attr( $datos['text_option'] ); ?>" data-role="destacado"><?php echo esc_textarea( $texto ); ?></textarea>
+                        <label><?php esc_html_e( 'Frase secundaria', 'cdb-form' ); ?></label>
+                        <textarea class="large-text" rows="2" name="<?php echo esc_attr( $sec_opt ); ?>" data-role="secundario"><?php echo esc_textarea( $secundario ); ?></textarea>
                         <p class="description"><?php echo esc_html( $datos['description'] ); ?></p>
                         <label><?php esc_html_e( 'Tipo/Color', 'cdb-form' ); ?></label>
                         <select name="<?php echo esc_attr( $datos['color_option'] ); ?>">

--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -12,6 +12,9 @@
     border-left: 4px solid transparent;
 }
 
+.cdb-mensaje-destacado { font-weight: 700; display: block; }
+.cdb-mensaje-secundario { display: block; margin-top: 4px; }
+
 /* Estilos utilizados únicamente en la pantalla de Configuración de Mensajes */
 .cdb-config-mensaje { margin-bottom: 20px; }
 .cdb-config-mensaje.editing { border: 1px solid #2271b1; padding: 10px; }

--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -8,7 +8,12 @@ jQuery(document).ready(function($){
 
     // Actualizar preview de texto
     $('.cdb-mensaje-edicion textarea').on('input', function(){
-        $(this).closest('.cdb-config-mensaje').find('.cdb-mensaje-preview').text($(this).val());
+        var cont   = $(this).closest('.cdb-config-mensaje');
+        var prev   = cont.find('.cdb-mensaje-preview');
+        var dest   = cont.find('textarea[data-role="destacado"]').val();
+        var sec    = cont.find('textarea[data-role="secundario"]').val();
+        prev.find('.cdb-mensaje-destacado').text(dest);
+        prev.find('.cdb-mensaje-secundario').text(sec).toggle(sec.trim().length > 0);
     });
 
     // Actualizar preview de colores y clase

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -126,9 +126,19 @@ function cdb_form_register_tipo_color( $slug, $args ) {
  * @return string HTML del mensaje listo para mostrarse.
  */
 function cdb_form_render_mensaje( $text_option, $color_option, $default_text, $default_tipo = 'aviso' ) {
-    $texto = get_option( $text_option, $default_text );
-    $tipo  = get_option( $color_option, $default_tipo );
-    $clase = cdb_form_get_tipo_color_class( $tipo );
+    $texto      = get_option( $text_option, $default_text );
+    $secundario = get_option( $text_option . '_secundaria', '' );
+    $tipo       = get_option( $color_option, $default_tipo );
+    $clase      = cdb_form_get_tipo_color_class( $tipo );
 
-    return '<div class="cdb-aviso ' . esc_attr( $clase ) . '">' . esc_html( $texto ) . '</div>';
+    $html  = '<div class="cdb-aviso ' . esc_attr( $clase ) . '">';
+    $html .= '<strong class="cdb-mensaje-destacado">' . wp_kses_post( $texto ) . '</strong>';
+
+    if ( ! empty( $secundario ) ) {
+        $html .= '<span class="cdb-mensaje-secundario">' . wp_kses_post( $secundario ) . '</span>';
+    }
+
+    $html .= '</div>';
+
+    return $html;
 }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -114,10 +114,12 @@ function cdb_bienvenida_usuario_shortcode() {
     $output .= '<h1>' . sprintf( esc_html__( '¡Hola, %s!', 'cdb-form' ), esc_html( $current_user->display_name ) ) . '</h1>';
 
     // Mensaje de bienvenida configurable.
-    $mensaje_bienvenida = get_option( 'cdb_mensaje_bienvenida', __( 'Gracias por colaborar con el Proyecto CdB.', 'cdb-form' ) );
-    $tipo_bienvenida    = get_option( 'cdb_color_bienvenida', 'info' );
-    $clase_bienvenida   = cdb_form_get_tipo_color_class( $tipo_bienvenida );
-    $output            .= '<div class="cdb-aviso ' . esc_attr( $clase_bienvenida ) . '">' . esc_html( $mensaje_bienvenida ) . '</div>';
+    $output .= cdb_form_render_mensaje(
+        'cdb_mensaje_bienvenida',
+        'cdb_color_bienvenida',
+        __( 'Gracias por colaborar con el Proyecto CdB.', 'cdb-form' ),
+        'info'
+    );
 
     // 4) Lógica específica para empleados.
     if (in_array('empleado', $roles)) {
@@ -128,11 +130,12 @@ function cdb_bienvenida_usuario_shortcode() {
             $output .= do_shortcode('[cdb_bienvenida_empleado]');
         } else {
             // Sin perfil: mensaje configurable e invitación a crear uno.
-            $mensaje       = get_option( 'cdb_mensaje_bienvenida_usuario', 'No tienes un perfil de empleado registrado.' );
-            $tipo_usuario  = get_option( 'cdb_color_bienvenida_usuario', 'aviso' );
-            $clase_usuario = cdb_form_get_tipo_color_class( $tipo_usuario );
-            $output       .= '<div class="cdb-aviso ' . esc_attr( $clase_usuario ) . '">' . esc_html( $mensaje ) . '</div>';
-            $output       .= do_shortcode('[cdb_form_empleado]');
+            $output .= cdb_form_render_mensaje(
+                'cdb_mensaje_bienvenida_usuario',
+                'cdb_color_bienvenida_usuario',
+                'No tienes un perfil de empleado registrado.'
+            );
+            $output .= do_shortcode('[cdb_form_empleado]');
         }
     }
 
@@ -175,10 +178,12 @@ function cdb_bienvenida_empleado_shortcode() {
         $exp_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$tabla_exp} WHERE empleado_id = %d", $empleado_id ) );
         if (0 === $exp_count) {
             // Mensaje configurable para empleados sin experiencia registrada.
-            $mensaje_exp = get_option( 'cdb_mensaje_empleado_sin_experiencia', __( 'Aún no has registrado ninguna experiencia laboral.', 'cdb-form' ) );
-            $tipo_exp    = get_option( 'cdb_color_empleado_sin_experiencia', 'info' );
-            $clase_exp   = cdb_form_get_tipo_color_class( $tipo_exp );
-            $output     .= '<div class="cdb-aviso ' . esc_attr( $clase_exp ) . '">' . esc_html( $mensaje_exp ) . '</div>';
+            $output .= cdb_form_render_mensaje(
+                'cdb_mensaje_empleado_sin_experiencia',
+                'cdb_color_empleado_sin_experiencia',
+                __( 'Aún no has registrado ninguna experiencia laboral.', 'cdb-form' ),
+                'info'
+            );
         }
 
         $empleado_nombre  = get_the_title($empleado_id);
@@ -218,11 +223,12 @@ function cdb_bienvenida_empleado_shortcode() {
     } else {
         // Mensaje para empleados que aún no han creado su perfil.
         // Configurable desde 'cdb_mensaje_bienvenida_usuario' y 'cdb_color_bienvenida_usuario'.
-        $mensaje    = get_option( 'cdb_mensaje_bienvenida_usuario', 'No tienes ningún perfil de empleado asignado.' );
-        $tipo_color = get_option( 'cdb_color_bienvenida_usuario', 'aviso' );
-        $clase      = cdb_form_get_tipo_color_class( $tipo_color );
-        $output    .= '<div class="cdb-aviso ' . esc_attr( $clase ) . '">' . esc_html( $mensaje ) . '</div>';
-        $output    .= do_shortcode('[cdb_form_empleado]');
+        $output .= cdb_form_render_mensaje(
+            'cdb_mensaje_bienvenida_usuario',
+            'cdb_color_bienvenida_usuario',
+            'No tienes ningún perfil de empleado asignado.'
+        );
+        $output .= do_shortcode('[cdb_form_empleado]');
     }
     return $output;
 }


### PR DESCRIPTION
## Summary
- allow messages to have primary and optional secondary phrases
- add preview fields in admin with live updates
- render highlighted phrase and optional secondary line in frontend

## Testing
- `php -l admin/config-mensajes.php`
- `php -l includes/messages.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_688e534fc4ac8327a026e058bc37cbaf