### PR TITLE
Ensure configurable message lines render on separate blocks

### DIFF
--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -12,8 +12,18 @@
     border-left: 4px solid transparent;
 }
 
-.cdb-mensaje-destacado { font-weight: 700; display: block; }
-.cdb-mensaje-secundario { display: block; margin-top: 4px; }
+.cdb-mensaje-destacado,
+.cdb-mensaje-secundario {
+    display: block;
+}
+
+.cdb-mensaje-destacado {
+    font-weight: 700;
+}
+
+.cdb-mensaje-secundario {
+    margin-top: 4px;
+}
 
 /* Estilos utilizados únicamente en la pantalla de Configuración de Mensajes */
 .cdb-config-mensaje { margin-bottom: 20px; }

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -156,7 +156,7 @@ function cdb_form_render_mensaje( $text_option, $color_option, $default_text, $d
     $html  = '<div class="cdb-aviso ' . esc_attr( $clase ) . '">';
     $html .= '<strong class="cdb-mensaje-destacado">' . wp_kses_post( $texto ) . '</strong>';
 
-    if ( ! empty( $secundario ) ) {
+    if ( '' !== $secundario ) {
         $html .= '<span class="cdb-mensaje-secundario">' . wp_kses_post( $secundario ) . '</span>';
     }
 


### PR DESCRIPTION
## Summary
- guarantee highlighted and secondary messages render on separate lines when present
- style `.cdb-mensaje-destacado` and `.cdb-mensaje-secundario` as block elements for clearer customization

## Testing
- `php -l includes/messages.php`


------
https://chatgpt.com/codex/tasks/task_e_688e5cdb4ac48327bbcee951f362fbd1