### PR TITLE
Ensure secondary message displays on new line

### DIFF
--- a/includes/messages.php
+++ b/includes/messages.php
@@ -217,7 +217,7 @@ function cdb_form_render_mensaje( $text_option, $color_option, $default_text, $d
     $html .= '<strong class="cdb-mensaje-destacado">' . wp_kses_post( $texto ) . '</strong>';
 
     if ( '' !== $secundario ) {
-        $html .= '<span class="cdb-mensaje-secundario">' . wp_kses_post( $secundario ) . '</span>';
+        $html .= '<br><span class="cdb-mensaje-secundario">' . wp_kses_post( $secundario ) . '</span>';
     }
 
     $html .= '</div>';


### PR DESCRIPTION
## Summary
- Add `<br>` before the secondary phrase so it always renders on a new line when present

## Testing
- `php -l includes/messages.php`


------
https://chatgpt.com/codex/tasks/task_e_688e641c781083279faf95b1a51e6369