### PR TITLE
feat: centralize remaining notices

### DIFF
--- a/includes/messages.php
+++ b/includes/messages.php
@@ -152,6 +152,44 @@ function cdb_form_get_option_compat( $keys, $default = '' ) {
 }
 
 /**
+ * Obtiene y renderiza un mensaje configurable usando una clave canónica.
+ *
+ * Permite mantener compatibilidad con nombres de opciones antiguos
+ * migrándolos automáticamente a la nueva nomenclatura.
+ *
+ * @param string $slug         Clave del mensaje.
+ * @param string $default_text Texto por defecto si no hay opción guardada.
+ * @param string $default_tipo Tipo/color por defecto.
+ * @return string HTML del mensaje listo para mostrarse.
+ */
+function cdb_form_get_mensaje( $slug, $default_text = '', $default_tipo = 'aviso' ) {
+    $map = array(
+        'cdb_aviso_sin_puntuacion'     => 'cdb_mensaje_puntuacion_no_disponible',
+        'cdb_empleado_no_encontrado'   => 'cdb_mensaje_empleado_no_encontrado',
+        'cdb_experiencia_sin_perfil'   => 'cdb_mensaje_experiencia_sin_perfil',
+        'cdb_bares_sin_resultados'     => 'cdb_mensaje_busqueda_sin_bares',
+        'cdb_empleados_vacio'          => 'cdb_mensaje_sin_empleados',
+        'cdb_empleados_sin_resultados' => 'cdb_mensaje_busqueda_sin_empleados',
+        'cdb_acceso_sin_login'         => 'cdb_mensaje_login_requerido',
+        'cdb_acceso_sin_permisos'      => 'cdb_mensaje_sin_permiso',
+    );
+
+    $text_option  = $slug;
+    $color_option = 'cdb_color_' . $slug;
+
+    if ( isset( $map[ $slug ] ) ) {
+        $old_text_option  = $map[ $slug ];
+        $old_color_option = str_replace( 'cdb_mensaje_', 'cdb_color_', $old_text_option );
+
+        // Migrar valores antiguos a las nuevas claves canónicas.
+        cdb_form_get_option_compat( array( $text_option, $old_text_option ), $default_text );
+        cdb_form_get_option_compat( array( $color_option, $old_color_option ), $default_tipo );
+    }
+
+    return cdb_form_render_mensaje( $text_option, $color_option, $default_text, $default_tipo );
+}
+
+/**
  * Renderiza un mensaje configurado desde las opciones del plugin.
  *
  * @param string $text_option  Nombre de la opción que almacena el texto.

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -215,7 +215,10 @@ function cdb_bienvenida_empleado_shortcode() {
             $puntuacion_total_final = round($puntuacion_total_final, 1); // Redondeamos a 1 decimal (opcional)
             $output .= cdb_generar_barra_progreso_simple($puntuacion_total_final);
         } else {
-            $output .= '<p>' . esc_html__( 'Puntuación Gráfica no disponible.', 'cdb-form' ) . '</p>';
+            $output .= cdb_form_get_mensaje(
+                'cdb_aviso_sin_puntuacion',
+                __( 'Puntuación Gráfica no disponible.', 'cdb-form' )
+            );
         }
 
         // Mostrar la Puntuación de Experiencia.
@@ -433,9 +436,8 @@ function cdb_mostrar_puntuacion_total() {
     }
     $puntuacion_total = get_post_meta($empleado_id, 'cdb_puntuacion_total', true);
     if (!$puntuacion_total) {
-        return cdb_form_render_mensaje(
-            'cdb_mensaje_puntuacion_no_disponible',
-            'cdb_color_puntuacion_no_disponible',
+        return cdb_form_get_mensaje(
+            'cdb_aviso_sin_puntuacion',
             __( 'Puntuación Gráfica no disponible.', 'cdb-form' ),
             'info'
         );
@@ -487,9 +489,8 @@ function cdb_top_empleados_experiencia_precalculada_shortcode() {
 
     // 5) Si no hay empleados, avisar
     if (!$query->have_posts()) {
-        return cdb_form_render_mensaje(
-            'cdb_mensaje_sin_empleados',
-            'cdb_color_sin_empleados',
+        return cdb_form_get_mensaje(
+            'cdb_empleados_vacio',
             __( 'No se encontraron empleados.', 'cdb-form' )
         );
     }
@@ -591,9 +592,8 @@ function cdb_top_empleados_puntuacion_total_shortcode() {
 
     // 5) Si no hay empleados, salimos.
     if (!$query->have_posts()) {
-        return cdb_form_render_mensaje(
-            'cdb_mensaje_sin_empleados',
-            'cdb_color_sin_empleados',
+        return cdb_form_get_mensaje(
+            'cdb_empleados_vacio',
             __( 'No se encontraron empleados con puntuación total.', 'cdb-form' )
         );
     }

--- a/public/form-bar.php
+++ b/public/form-bar.php
@@ -12,9 +12,8 @@ add_shortcode( 'form-bar', 'cdb_form_bar' );
 function cdb_form_bar() {
     // Comprobar si el usuario está conectado.
     if ( ! is_user_logged_in() ) {
-        return cdb_form_render_mensaje(
-            'cdb_mensaje_login_requerido',
-            'cdb_color_login_requerido',
+        return cdb_form_get_mensaje(
+            'cdb_acceso_sin_login',
             __( 'Debes iniciar sesión para actualizar el estado de tu bar.', 'cdb-form' )
         );
     }

--- a/public/form-empleado.php
+++ b/public/form-empleado.php
@@ -24,18 +24,16 @@ function cdb_usuario_es_empleado() {
 function cdb_form_empleado() {
     // Comprobar si el usuario está conectado.
     if ( ! is_user_logged_in() ) {
-        return cdb_form_render_mensaje(
-            'cdb_mensaje_login_requerido',
-            'cdb_color_login_requerido',
+        return cdb_form_get_mensaje(
+            'cdb_acceso_sin_login',
             __( 'Debes iniciar sesión para actualizar tu estado.', 'cdb-form' )
         );
     }
 
     // Comprobar si el usuario tiene el rol "Empleado".
     if ( ! cdb_usuario_es_empleado() ) {
-        return cdb_form_render_mensaje(
-            'cdb_mensaje_sin_permiso',
-            'cdb_color_sin_permiso',
+        return cdb_form_get_mensaje(
+            'cdb_acceso_sin_permisos',
             __( 'No tienes permisos para acceder a esta sección.', 'cdb-form' )
         );
     }

--- a/templates/busqueda-bares-table.php
+++ b/templates/busqueda-bares-table.php
@@ -1,7 +1,6 @@
 <?php if ( empty( $bares ) ) : ?>
-    <?php echo cdb_form_render_mensaje(
-        'cdb_mensaje_busqueda_sin_bares',
-        'cdb_color_busqueda_sin_bares',
+    <?php echo cdb_form_get_mensaje(
+        'cdb_bares_sin_resultados',
         __( 'No se encontraron bares con esos filtros.', 'cdb-form' )
     ); ?>
 <?php else : ?>

--- a/templates/busqueda-empleados-table.php
+++ b/templates/busqueda-empleados-table.php
@@ -1,7 +1,6 @@
 <?php if ( empty( $empleados ) ) : ?>
-    <?php echo cdb_form_render_mensaje(
-        'cdb_mensaje_busqueda_sin_empleados',
-        'cdb_color_busqueda_sin_empleados',
+    <?php echo cdb_form_get_mensaje(
+        'cdb_empleados_sin_resultados',
         __( 'No se encontraron empleados con esos filtros.', 'cdb-form' )
     ); ?>
 <?php else : ?>

--- a/templates/form-empleado-template.php
+++ b/templates/form-empleado-template.php
@@ -29,6 +29,10 @@ if (!empty($existing_empleado)) {
     $empleado_disponible = get_post_meta($empleado_id, 'disponible', true) ?: '1';
     $button_text         = __( 'Actualizar Empleado', 'cdb-form' );
 } else {
+    echo cdb_form_get_mensaje(
+        'cdb_empleado_no_encontrado',
+        __( 'Empleado no encontrado.', 'cdb-form' )
+    );
     $empleado_id         = 0;
     $empleado_nombre     = '';
     $empleado_disponible = '1';

--- a/templates/form-experiencia-template.php
+++ b/templates/form-experiencia-template.php
@@ -18,9 +18,8 @@ if (!$current_user->exists()) {
 // Obtener la ID del empleado asociado al usuario actual mediante la función específica.
 $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
 if (!$empleado_id) {
-    echo cdb_form_render_mensaje(
-        'cdb_mensaje_experiencia_sin_perfil',
-        'cdb_color_experiencia_sin_perfil',
+    echo cdb_form_get_mensaje(
+        'cdb_experiencia_sin_perfil',
         __( 'No tienes un perfil de empleado registrado. Para registrar experiencia, primero debes crear tu perfil de empleado.', 'cdb-form' )
     );
     echo do_shortcode('[cdb_form_empleado]');


### PR DESCRIPTION
## Summary
- centralize configurable messages behind `cdb_form_get_mensaje`
- use dynamic messages for missing scores and empty employee/bar searches
- route public form access checks through configurable messages

## Testing
- `php -l includes/messages.php`
- `php -l includes/shortcodes.php`
- `php -l templates/form-empleado-template.php`
- `php -l templates/form-experiencia-template.php`
- `php -l templates/busqueda-bares-table.php`
- `php -l templates/busqueda-empleados-table.php`
- `php -l public/form-bar.php`
- `php -l public/form-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_688e7af9f7308327bd7b6f5abdbea329