### PR TITLE
Add default messages and admin placeholders

### DIFF
--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -119,6 +119,18 @@ function cdb_form_config_mensajes_page() {
         ),
     );
 
+    global $cdb_form_defaults;
+    $placeholder_map = array(
+        'cdb_mensaje_puntuacion_no_disponible' => 'cdb_aviso_sin_puntuacion',
+        'cdb_mensaje_empleado_no_encontrado'   => 'cdb_empleado_no_encontrado',
+        'cdb_mensaje_experiencia_sin_perfil'   => 'cdb_experiencia_sin_perfil',
+        'cdb_mensaje_busqueda_sin_bares'       => 'cdb_bares_sin_resultados',
+        'cdb_mensaje_sin_empleados'            => 'cdb_empleados_vacio',
+        'cdb_mensaje_busqueda_sin_empleados'   => 'cdb_empleados_sin_resultados',
+        'cdb_mensaje_login_requerido'          => 'cdb_acceso_sin_login',
+        'cdb_mensaje_sin_permiso'              => 'cdb_acceso_sin_permisos',
+    );
+
     // Ejemplos de futuros mensajes que podrían añadirse:
     // 'exito_guardado' => array(
     //     'text_option'  => 'cdb_mensaje_exito_guardado',
@@ -198,6 +210,7 @@ function cdb_form_config_mensajes_page() {
     <div class="wrap">
         <h1><?php esc_html_e( 'Configuración de Mensajes y Avisos', 'cdb-form' ); ?></h1>
         <p><?php esc_html_e( 'Este panel centraliza la gestión de mensajes/avisos de la experiencia de usuario CdB.', 'cdb-form' ); ?></p>
+        <div class="notice notice-info"><p><?php esc_html_e( 'Si dejas un campo vacío se mostrará el texto por defecto', 'cdb-form' ); ?></p></div>
         <?php if ( $mensaje_guardado ) :
             $clase_notice = cdb_form_get_tipo_color_class( $tipo_mensaje );
             $bg_notice    = $tipos_color[ $tipo_mensaje ]['color'] ?? '#000';
@@ -211,21 +224,25 @@ function cdb_form_config_mensajes_page() {
             <?php wp_nonce_field( 'cdb_form_config_mensajes_save', 'cdb_form_config_mensajes_nonce' ); ?>
 
             <?php foreach ( $mensajes as $id => $datos ) :
-                $texto = cdb_form_get_option_compat(
-                    array(
-                        $datos['text_option'],
-                        $datos['text_option'] . '_destacado',
-                        $datos['text_option'] . '_principal',
-                        $datos['text_option'] . '_mensaje_destacado',
-                        $datos['text_option'] . '_mensaje_principal',
-                        $datos['text_option'] . '_frase_destacada',
-                        $datos['text_option'] . '_frase_principal',
-                        $datos['text_option'] . '_featured',
-                        $datos['text_option'] . '_primary',
-                        $datos['text_option'] . '_highlight',
-                    ),
-                    ''
-                );
+            $texto = cdb_form_get_option_compat(
+                array(
+                    $datos['text_option'],
+                    $datos['text_option'] . '_destacado',
+                    $datos['text_option'] . '_principal',
+                    $datos['text_option'] . '_mensaje_destacado',
+                    $datos['text_option'] . '_mensaje_principal',
+                    $datos['text_option'] . '_frase_destacada',
+                    $datos['text_option'] . '_frase_principal',
+                    $datos['text_option'] . '_featured',
+                    $datos['text_option'] . '_primary',
+                    $datos['text_option'] . '_highlight',
+                ),
+                ''
+            );
+            $placeholder = '';
+            if ( isset( $placeholder_map[ $datos['text_option'] ] ) && isset( $cdb_form_defaults[ $placeholder_map[ $datos['text_option'] ] ] ) ) {
+                $placeholder = $cdb_form_defaults[ $placeholder_map[ $datos['text_option'] ] ];
+            }
                 $sec_opt    = $datos['text_option'] . '_secundaria';
                 $secundario = cdb_form_get_option_compat(
                     array(
@@ -254,7 +271,7 @@ function cdb_form_config_mensajes_page() {
                     <button type="button" class="button cdb-edit-mensaje"><?php esc_html_e( 'Editar', 'cdb-form' ); ?></button>
                     <div class="cdb-mensaje-edicion" style="display:none;">
                         <label><?php esc_html_e( 'Frase destacada', 'cdb-form' ); ?></label>
-                        <textarea class="large-text" rows="2" name="<?php echo esc_attr( $datos['text_option'] ); ?>" data-role="destacado"><?php echo esc_textarea( $texto ); ?></textarea>
+                        <textarea class="large-text" rows="2" name="<?php echo esc_attr( $datos['text_option'] ); ?>" data-role="destacado" placeholder="<?php echo esc_attr( $placeholder ); ?>"><?php echo esc_textarea( $texto ); ?></textarea>
                         <label><?php esc_html_e( 'Frase secundaria', 'cdb-form' ); ?></label>
                         <textarea class="large-text" rows="2" name="<?php echo esc_attr( $sec_opt ); ?>" data-role="secundario"><?php echo esc_textarea( $secundario ); ?></textarea>
                         <p class="description"><?php echo esc_html( $datos['description'] ); ?></p>

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -216,8 +216,7 @@ function cdb_bienvenida_empleado_shortcode() {
             $output .= cdb_generar_barra_progreso_simple($puntuacion_total_final);
         } else {
             $output .= cdb_form_get_mensaje(
-                'cdb_aviso_sin_puntuacion',
-                __( 'Puntuación Gráfica no disponible.', 'cdb-form' )
+                'cdb_aviso_sin_puntuacion'
             );
         }
 
@@ -438,7 +437,6 @@ function cdb_mostrar_puntuacion_total() {
     if (!$puntuacion_total) {
         return cdb_form_get_mensaje(
             'cdb_aviso_sin_puntuacion',
-            __( 'Puntuación Gráfica no disponible.', 'cdb-form' ),
             'info'
         );
     }
@@ -490,8 +488,7 @@ function cdb_top_empleados_experiencia_precalculada_shortcode() {
     // 5) Si no hay empleados, avisar
     if (!$query->have_posts()) {
         return cdb_form_get_mensaje(
-            'cdb_empleados_vacio',
-            __( 'No se encontraron empleados.', 'cdb-form' )
+            'cdb_empleados_vacio'
         );
     }
 
@@ -593,8 +590,7 @@ function cdb_top_empleados_puntuacion_total_shortcode() {
     // 5) Si no hay empleados, salimos.
     if (!$query->have_posts()) {
         return cdb_form_get_mensaje(
-            'cdb_empleados_vacio',
-            __( 'No se encontraron empleados con puntuación total.', 'cdb-form' )
+            'cdb_empleados_vacio'
         );
     }
 

--- a/public/form-bar.php
+++ b/public/form-bar.php
@@ -13,8 +13,7 @@ function cdb_form_bar() {
     // Comprobar si el usuario está conectado.
     if ( ! is_user_logged_in() ) {
         return cdb_form_get_mensaje(
-            'cdb_acceso_sin_login',
-            __( 'Debes iniciar sesión para actualizar el estado de tu bar.', 'cdb-form' )
+            'cdb_acceso_sin_login'
         );
     }
 

--- a/public/form-empleado.php
+++ b/public/form-empleado.php
@@ -25,16 +25,14 @@ function cdb_form_empleado() {
     // Comprobar si el usuario está conectado.
     if ( ! is_user_logged_in() ) {
         return cdb_form_get_mensaje(
-            'cdb_acceso_sin_login',
-            __( 'Debes iniciar sesión para actualizar tu estado.', 'cdb-form' )
+            'cdb_acceso_sin_login'
         );
     }
 
     // Comprobar si el usuario tiene el rol "Empleado".
     if ( ! cdb_usuario_es_empleado() ) {
         return cdb_form_get_mensaje(
-            'cdb_acceso_sin_permisos',
-            __( 'No tienes permisos para acceder a esta sección.', 'cdb-form' )
+            'cdb_acceso_sin_permisos'
         );
     }
 

--- a/templates/busqueda-bares-table.php
+++ b/templates/busqueda-bares-table.php
@@ -1,7 +1,6 @@
 <?php if ( empty( $bares ) ) : ?>
     <?php echo cdb_form_get_mensaje(
-        'cdb_bares_sin_resultados',
-        __( 'No se encontraron bares con esos filtros.', 'cdb-form' )
+        'cdb_bares_sin_resultados'
     ); ?>
 <?php else : ?>
 <table class="cdb-busqueda-table">

--- a/templates/busqueda-empleados-table.php
+++ b/templates/busqueda-empleados-table.php
@@ -1,7 +1,6 @@
 <?php if ( empty( $empleados ) ) : ?>
     <?php echo cdb_form_get_mensaje(
-        'cdb_empleados_sin_resultados',
-        __( 'No se encontraron empleados con esos filtros.', 'cdb-form' )
+        'cdb_empleados_sin_resultados'
     ); ?>
 <?php else : ?>
 <table class="cdb-busqueda-table">

--- a/templates/form-empleado-template.php
+++ b/templates/form-empleado-template.php
@@ -30,8 +30,7 @@ if (!empty($existing_empleado)) {
     $button_text         = __( 'Actualizar Empleado', 'cdb-form' );
 } else {
     echo cdb_form_get_mensaje(
-        'cdb_empleado_no_encontrado',
-        __( 'Empleado no encontrado.', 'cdb-form' )
+        'cdb_empleado_no_encontrado'
     );
     $empleado_id         = 0;
     $empleado_nombre     = '';

--- a/templates/form-experiencia-template.php
+++ b/templates/form-experiencia-template.php
@@ -19,8 +19,7 @@ if (!$current_user->exists()) {
 $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
 if (!$empleado_id) {
     echo cdb_form_get_mensaje(
-        'cdb_experiencia_sin_perfil',
-        __( 'No tienes un perfil de empleado registrado. Para registrar experiencia, primero debes crear tu perfil de empleado.', 'cdb-form' )
+        'cdb_experiencia_sin_perfil'
     );
     echo do_shortcode('[cdb_form_empleado]');
     return;


### PR DESCRIPTION
## Summary
- centralize default message text in `$cdb_form_defaults`
- ensure `cdb_form_get_mensaje` falls back to defaults when options are empty
- show default text placeholders and info notice in message configuration admin page

## Testing
- `php -l includes/messages.php`
- `php -l admin/config-mensajes.php`
- `php -l public/form-empleado.php`
- `php -l public/form-bar.php`
- `php -l includes/shortcodes.php`
- `php -l templates/busqueda-bares-table.php`
- `php -l templates/busqueda-empleados-table.php`
- `php -l templates/form-empleado-template.php`
- `php -l templates/form-experiencia-template.php`

------
https://chatgpt.com/codex/tasks/task_e_688e7f16a8248327855915bb6e700854