### PR TITLE
Actualiza mensajes por defecto con frases destacadas y secundarias

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ También puedes registrar variantes desde código utilizando `cdb_form_register_
 <!-- ACTUALIZAR ESTA TABLA SI SE AÑADEN NUEVAS CLAVES EN $cdb_form_defaults -->
 | Clave | Texto por defecto | Contexto (dónde aparece) |
 | --- | --- | --- |
-| cdb_acceso_sin_login | Debes iniciar sesión para acceder a esta sección. | Formularios de bar o empleado cuando el usuario no ha iniciado sesión |
-| cdb_acceso_sin_permisos | No tienes permisos para ver este contenido. | Formulario de empleado cuando el usuario no tiene permisos |
-| cdb_aviso_sin_puntuacion | Puntuación gráfica no disponible. | Panel de empleado cuando no hay gráfico |
-| cdb_bares_sin_resultados | No hay bares que coincidan con tu búsqueda. | Búsqueda de bares sin resultados |
-| cdb_empleado_no_encontrado | Empleado no encontrado. | Formulario de empleado cuando no existe perfil asociado |
-| cdb_empleados_sin_resultados | Sin coincidencias para tu búsqueda. | Búsqueda de empleados sin resultados |
-| cdb_empleados_vacio | Aún no hay empleados registrados. | Rankings de empleados cuando no existen registros |
-| cdb_experiencia_sin_perfil | Para registrar experiencia debes crear antes tu perfil de empleado. | Formulario de experiencia sin perfil de empleado |
+| cdb_acceso_sin_login | **Debes iniciar sesión para acceder.** \| Inicia sesión o regístrate para continuar. | Formularios de bar o empleado cuando el usuario no ha iniciado sesión |
+| cdb_acceso_sin_permisos | **No tienes permisos para ver este contenido.** \| Contacta con un admin si crees que es un error. | Formulario de empleado cuando el usuario no tiene permisos |
+| cdb_aviso_sin_puntuacion | **Puntuación gráfica no disponible.** \| Añade más valoraciones para generar tu gráfico. | Panel de empleado cuando no hay gráfico |
+| cdb_bares_sin_resultados | **No hay bares que coincidan con tu búsqueda.** \| Ajusta filtros o prueba con otro término. | Búsqueda de bares sin resultados |
+| cdb_empleado_no_encontrado | **Empleado no encontrado.** \| Crea primero tu perfil de empleado para continuar. | Formulario de empleado cuando no existe perfil asociado |
+| cdb_empleados_sin_resultados | **Sin coincidencias para tu búsqueda.** \| Modifica los criterios e inténtalo de nuevo. | Búsqueda de empleados sin resultados |
+| cdb_empleados_vacio | **Aún no hay empleados registrados.** \| ¡Sé el primero en unirte al proyecto! | Rankings de empleados cuando no existen registros |
+| cdb_experiencia_sin_perfil | **Para registrar experiencia debes crear tu perfil.** \| Completa tu información de empleado y vuelve aquí. | Formulario de experiencia sin perfil de empleado |
 
 Para personalizar estos textos ve al submenú **Cdb Form → Configuración de Mensajes y Avisos**.
 

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -20,14 +20,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Valores por defecto de mensajes y avisos.
 $cdb_form_defaults = array(
-    'cdb_aviso_sin_puntuacion'     => __( 'Puntuación gráfica no disponible.', 'cdb-form' ),
-    'cdb_empleado_no_encontrado'   => __( 'Empleado no encontrado.', 'cdb-form' ),
-    'cdb_experiencia_sin_perfil'   => __( 'Para registrar experiencia debes crear antes tu perfil de empleado.', 'cdb-form' ),
-    'cdb_bares_sin_resultados'     => __( 'No hay bares que coincidan con tu búsqueda.', 'cdb-form' ),
-    'cdb_empleados_vacio'          => __( 'Aún no hay empleados registrados.', 'cdb-form' ),
-    'cdb_empleados_sin_resultados' => __( 'Sin coincidencias para tu búsqueda.', 'cdb-form' ),
-    'cdb_acceso_sin_login'         => __( 'Debes iniciar sesión para acceder a esta sección.', 'cdb-form' ),
-    'cdb_acceso_sin_permisos'      => __( 'No tienes permisos para ver este contenido.', 'cdb-form' ),
+    'cdb_aviso_sin_puntuacion'     => __( 'Puntuación gráfica no disponible.| Añade más valoraciones para generar tu gráfico.', 'cdb-form' ),
+    'cdb_empleado_no_encontrado'   => __( 'Empleado no encontrado.| Crea primero tu perfil de empleado para continuar.', 'cdb-form' ),
+    'cdb_experiencia_sin_perfil'   => __( 'Para registrar experiencia debes crear tu perfil.| Completa tu información de empleado y vuelve aquí.', 'cdb-form' ),
+    'cdb_bares_sin_resultados'     => __( 'No hay bares que coincidan con tu búsqueda.| Ajusta filtros o prueba con otro término.', 'cdb-form' ),
+    'cdb_empleados_vacio'          => __( 'Aún no hay empleados registrados.| ¡Sé el primero en unirte al proyecto!', 'cdb-form' ),
+    'cdb_empleados_sin_resultados' => __( 'Sin coincidencias para tu búsqueda.| Modifica los criterios e inténtalo de nuevo.', 'cdb-form' ),
+    'cdb_acceso_sin_login'         => __( 'Debes iniciar sesión para acceder.| Inicia sesión o regístrate para continuar.', 'cdb-form' ),
+    'cdb_acceso_sin_permisos'      => __( 'No tienes permisos para ver este contenido.| Contacta con un admin si crees que es un error.', 'cdb-form' ),
     // …añade aquí cualquier clave nueva que surja
 );
 


### PR DESCRIPTION
## Summary
- Ajusta mensajes por defecto para usar formato "destacado|secundario" con tono cercano
- Documenta nuevos textos en tabla de README

## Testing
- `grep -n cdb_aviso_sin_puntuacion includes/messages.php`
- `php <<'PHP'
<?php
define('ABSPATH', __DIR__);
if(!function_exists('__')){function __($t){return $t;}}
include 'includes/messages.php';
$count=0;
foreach($cdb_form_defaults as $t){$count+=substr_count($t,'|');}
echo $count, PHP_EOL;
PHP`


------
https://chatgpt.com/codex/tasks/task_e_688e86a8b72483279047894f94d6e378