### PR TITLE
Route JS alerts through configurable message system

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ También puedes registrar variantes desde código utilizando `cdb_form_register_
 | cdb_empleados_sin_resultados | **Sin coincidencias para tu búsqueda.** \| Modifica los criterios e inténtalo de nuevo. | Búsqueda de empleados sin resultados |
 | cdb_empleados_vacio | **Aún no hay empleados registrados.** \| ¡Sé el primero en unirte al proyecto! | Rankings de empleados cuando no existen registros |
 | cdb_experiencia_sin_perfil | **Para registrar experiencia debes crear tu perfil.** \| Completa tu información de empleado y vuelve aquí. | Formulario de experiencia sin perfil de empleado |
+| cdb_ajax_exito_empleado | **Empleado creado correctamente.** \| El perfil se ha guardado sin problemas. | Respuesta exitosa al crear empleado por AJAX |
+| cdb_ajax_error_empleado | **Error al crear empleado.** \| Inténtalo de nuevo más tarde. | Fallo al crear empleado por AJAX |
+| cdb_ajax_exito_experiencia | **Experiencia registrada.** \| Se ha guardado la experiencia. | Registro de experiencia por AJAX |
+| cdb_ajax_empleados_sin_resultados | **Sin resultados.** \| No hay empleados que coincidan con tu búsqueda. | Búsqueda de empleados sin coincidencias (AJAX) |
+| cdb_ajax_bares_sin_resultados | **Sin resultados.** \| No hay bares que coincidan con tu búsqueda. | Búsqueda de bares sin coincidencias (AJAX) |
+| cdb_ajax_disponibilidad_actualizada | **Disponibilidad actualizada correctamente.** \| Los datos se han guardado. | Actualización de disponibilidad del empleado |
+| cdb_ajax_error_disponibilidad | **Hubo un problema al actualizar la disponibilidad.** \| Inténtalo de nuevo más tarde. | Error al actualizar disponibilidad del empleado |
+| cdb_ajax_estado_bar_actualizado | **Estado del bar actualizado correctamente.** \| Los datos se han guardado. | Actualización del estado del bar |
+| cdb_ajax_error_estado_bar | **Hubo un problema al actualizar el estado del bar.** \| Inténtalo de nuevo más tarde. | Error al actualizar estado del bar |
+| cdb_ajax_error_comunicacion | **Error de comunicación.** \| No se pudo contactar con el servidor. | Fallo de conexión AJAX |
+| cdb_ajax_error_anio_cifras | **El año debe tener 4 cifras.** \| Introduce un año válido. | Validación de filtros de búsqueda (año con 4 cifras) |
+| cdb_ajax_error_nombre_invalido | **Selecciona un nombre válido.** \| Elige una opción de la lista. | Validación de filtro de nombre en búsqueda de empleados |
+| cdb_ajax_error_posicion_invalida | **Selecciona una posición válida.** \| Usa la ayuda de autocompletado. | Validación de filtro de posición en búsqueda de empleados |
+| cdb_ajax_error_bar_invalido | **Selecciona un bar válido.** \| Usa la ayuda de autocompletado. | Validación de filtro de bar en búsquedas |
+| cdb_ajax_error_anio_invalido | **Selecciona un año válido.** \| Usa un formato de cuatro cifras. | Validación de filtro de año en búsqueda de empleados |
+| cdb_ajax_error_zona_invalida | **Selecciona una zona válida.** \| Elige una opción de la lista. | Validación de filtro de zona en búsqueda de bares |
 
 Para personalizar estos textos ve al submenú **Cdb Form → Configuración de Mensajes y Avisos**.
 

--- a/assets/js/frontend-scripts.js
+++ b/assets/js/frontend-scripts.js
@@ -17,15 +17,15 @@ jQuery(document).ready(function($) {
                 console.log("Respuesta AJAX (Empleado):", response); // Depuración en consola
 
                 if (response.success) {
-                    alert('Disponibilidad actualizada correctamente.');
+                    window.alert(cdbMsgs.cdb_ajax_disponibilidad_actualizada);
                     location.reload();
                 } else {
-                    alert('Error: ' + response.data.message);
+                    window.alert(response.data.message || cdbMsgs.cdb_ajax_error_disponibilidad);
                 }
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.error("Error AJAX (Empleado):", textStatus, errorThrown);
-                alert('Hubo un problema al actualizar la disponibilidad.');
+                window.alert(cdbMsgs.cdb_ajax_error_disponibilidad);
             }
         });
     });
@@ -48,15 +48,15 @@ jQuery(document).ready(function($) {
                 console.log("Respuesta AJAX (Bar):", response); // Depuración en consola
 
                 if (response.success) {
-                    alert('Estado del bar actualizado correctamente.');
+                    window.alert(cdbMsgs.cdb_ajax_estado_bar_actualizado);
                     location.reload();
                 } else {
-                    alert('Error: ' + response.data.message);
+                    window.alert(response.data.message || cdbMsgs.cdb_ajax_error_estado_bar);
                 }
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.error("Error AJAX (Bar):", textStatus, errorThrown);
-                alert('Hubo un problema al actualizar el estado del bar.');
+                window.alert(cdbMsgs.cdb_ajax_error_estado_bar);
             }
         });
     });
@@ -78,12 +78,12 @@ jQuery(document).ready(function($) {
             if(resp.success){
                 jQuery('#cdb-busqueda-empleados-resultados').html(resp.data.html);
             } else if (resp.data && resp.data.message) {
-                alert(resp.data.message);
+                window.alert(resp.data.message);
             }
             if (spinner) spinner.style.display = 'none';
         }).fail(function(jqXHR){
             if (spinner) spinner.style.display = 'none';
-            alert('Error de comunicación');
+            window.alert(cdbMsgs.cdb_ajax_error_comunicacion);
             console.error('cdb_buscar_empleados AJAX fail', jqXHR);
         });
     }
@@ -216,23 +216,23 @@ jQuery(document).ready(function($) {
 
         function validarFiltros(){
             if(anioInput.value && !/^[0-9]{4}$/.test(anioInput.value)){
-                alert('El año debe tener 4 cifras');
+                window.alert(cdbMsgs.cdb_ajax_error_anio_cifras);
                 return false;
             }
             if(nombreInput.value && !nombreInput.dataset.valid){
-                alert('Selecciona un nombre válido');
+                window.alert(cdbMsgs.cdb_ajax_error_nombre_invalido);
                 return false;
             }
             if(posInput.value && !posInput.dataset.valid){
-                alert('Selecciona una posición válida');
+                window.alert(cdbMsgs.cdb_ajax_error_posicion_invalida);
                 return false;
             }
             if(barInput.value && !barInput.dataset.valid){
-                alert('Selecciona un bar válido');
+                window.alert(cdbMsgs.cdb_ajax_error_bar_invalido);
                 return false;
             }
             if(anioInput.value && !anioInput.dataset.valid){
-                alert('Selecciona un año válido');
+                window.alert(cdbMsgs.cdb_ajax_error_anio_invalido);
                 return false;
             }
             return true;
@@ -271,12 +271,12 @@ jQuery(document).ready(function($) {
             if(resp.success){
                 jQuery('#cdb-busqueda-bares-resultados').html(resp.data.html);
             } else if (resp.data && resp.data.message){
-                alert(resp.data.message);
+                window.alert(resp.data.message);
             }
             if (spinner) spinner.style.display = 'none';
         }).fail(function(jqXHR){
             if (spinner) spinner.style.display = 'none';
-            alert('Error de comunicación');
+            window.alert(cdbMsgs.cdb_ajax_error_comunicacion);
             console.error('cdb_buscar_bares AJAX fail', jqXHR);
         });
     }
@@ -359,15 +359,15 @@ jQuery(document).ready(function($) {
 
         function validarFiltrosBares(){
             if(aperturaInput.value && !/^[0-9]{4}$/.test(aperturaInput.value)){
-                alert('El año debe tener 4 cifras');
+                window.alert(cdbMsgs.cdb_ajax_error_anio_cifras);
                 return false;
             }
             if(bNombreInput.value && !bNombreInput.dataset.valid){
-                alert('Selecciona un bar válido');
+                window.alert(cdbMsgs.cdb_ajax_error_bar_invalido);
                 return false;
             }
             if(zonaInput.value && !zonaInput.dataset.valid){
-                alert('Selecciona una zona válida');
+                window.alert(cdbMsgs.cdb_ajax_error_zona_invalida);
                 return false;
             }
             return true;

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -28,6 +28,22 @@ $cdb_form_defaults = array(
     'cdb_empleados_sin_resultados' => __( 'Sin coincidencias para tu búsqueda.| Modifica los criterios e inténtalo de nuevo.', 'cdb-form' ),
     'cdb_acceso_sin_login'         => __( 'Debes iniciar sesión para acceder.| Inicia sesión o regístrate para continuar.', 'cdb-form' ),
     'cdb_acceso_sin_permisos'      => __( 'No tienes permisos para ver este contenido.| Contacta con un admin si crees que es un error.', 'cdb-form' ),
+    'cdb_ajax_exito_empleado'      => __( 'Empleado creado correctamente.| El perfil se ha guardado sin problemas.', 'cdb-form' ),
+    'cdb_ajax_error_empleado'      => __( 'Error al crear empleado.| Inténtalo de nuevo más tarde.', 'cdb-form' ),
+    'cdb_ajax_exito_experiencia'   => __( 'Experiencia registrada.| Se ha guardado la experiencia.', 'cdb-form' ),
+    'cdb_ajax_empleados_sin_resultados' => __( 'Sin resultados.| No hay empleados que coincidan con tu búsqueda.', 'cdb-form' ),
+    'cdb_ajax_bares_sin_resultados'     => __( 'Sin resultados.| No hay bares que coincidan con tu búsqueda.', 'cdb-form' ),
+    'cdb_ajax_disponibilidad_actualizada' => __( 'Disponibilidad actualizada correctamente.| Los datos se han guardado.', 'cdb-form' ),
+    'cdb_ajax_error_disponibilidad' => __( 'Hubo un problema al actualizar la disponibilidad.| Inténtalo de nuevo más tarde.', 'cdb-form' ),
+    'cdb_ajax_estado_bar_actualizado' => __( 'Estado del bar actualizado correctamente.| Los datos se han guardado.', 'cdb-form' ),
+    'cdb_ajax_error_estado_bar'    => __( 'Hubo un problema al actualizar el estado del bar.| Inténtalo de nuevo más tarde.', 'cdb-form' ),
+    'cdb_ajax_error_comunicacion'  => __( 'Error de comunicación.| No se pudo contactar con el servidor.', 'cdb-form' ),
+    'cdb_ajax_error_anio_cifras'   => __( 'El año debe tener 4 cifras.| Introduce un año válido.', 'cdb-form' ),
+    'cdb_ajax_error_nombre_invalido' => __( 'Selecciona un nombre válido.| Elige una opción de la lista.', 'cdb-form' ),
+    'cdb_ajax_error_posicion_invalida' => __( 'Selecciona una posición válida.| Usa la ayuda de autocompletado.', 'cdb-form' ),
+    'cdb_ajax_error_bar_invalido'  => __( 'Selecciona un bar válido.| Usa la ayuda de autocompletado.', 'cdb-form' ),
+    'cdb_ajax_error_anio_invalido' => __( 'Selecciona un año válido.| Usa un formato de cuatro cifras.', 'cdb-form' ),
+    'cdb_ajax_error_zona_invalida' => __( 'Selecciona una zona válida.| Elige una opción de la lista.', 'cdb-form' ),
     // …añade aquí cualquier clave nueva que surja
 );
 
@@ -213,6 +229,58 @@ function cdb_form_get_mensaje( $clave, $tipo = 'aviso' ) {
     $html .= '</div>';
 
     return $html;
+}
+
+/**
+ * Devuelve un mensaje configurable como texto plano para uso en JavaScript.
+ *
+ * @param string $clave Clave del mensaje.
+ * @return string Texto plano del mensaje.
+ */
+function cdb_form_get_mensaje_js( $clave ) {
+    global $cdb_form_defaults;
+
+    $default   = $cdb_form_defaults[ $clave ] ?? '';
+    $texto     = cdb_form_get_option_compat(
+        array(
+            $clave,
+            $clave . '_destacado',
+            $clave . '_principal',
+            $clave . '_mensaje_destacado',
+            $clave . '_mensaje_principal',
+            $clave . '_frase_destacada',
+            $clave . '_frase_principal',
+            $clave . '_featured',
+            $clave . '_primary',
+            $clave . '_highlight',
+        ),
+        $default
+    );
+    $secundario = cdb_form_get_option_compat(
+        array(
+            $clave . '_secundaria',
+            $clave . '_secundario',
+            $clave . '_mensaje_secundario',
+            $clave . '_mensaje_secundaria',
+            $clave . '_frase_secundaria',
+            $clave . '_frase_secundario',
+            $clave . '_secondary',
+        ),
+        ''
+    );
+
+    if ( '' === $secundario && strpos( $texto, '|' ) !== false ) {
+        $parts = array_map( 'trim', explode( '|', $texto, 2 ) );
+        $texto = $parts[0];
+        $secundario = $parts[1] ?? '';
+    }
+
+    $mensaje = $texto;
+    if ( '' !== $secundario ) {
+        $mensaje .= ' ' . $secundario;
+    }
+
+    return trim( wp_strip_all_tags( $mensaje ) );
 }
 
 /**

--- a/public/enqueue.php
+++ b/public/enqueue.php
@@ -58,5 +58,29 @@ function cdb_form_public_enqueue() {
         'ajaxurl' => admin_url( 'admin-ajax.php' ),
         'nonce'   => wp_create_nonce( 'cdb_form_nonce' ), // Agregamos el nonce
     ) );
+
+    // Pasar mensajes configurables a JavaScript.
+    wp_localize_script(
+        'cdb-form-frontend-script',
+        'cdbMsgs',
+        array(
+            'cdb_ajax_exito_empleado'       => cdb_form_get_mensaje_js( 'cdb_ajax_exito_empleado' ),
+            'cdb_ajax_error_empleado'       => cdb_form_get_mensaje_js( 'cdb_ajax_error_empleado' ),
+            'cdb_ajax_exito_experiencia'    => cdb_form_get_mensaje_js( 'cdb_ajax_exito_experiencia' ),
+            'cdb_ajax_empleados_sin_resultados' => cdb_form_get_mensaje_js( 'cdb_ajax_empleados_sin_resultados' ),
+            'cdb_ajax_bares_sin_resultados'     => cdb_form_get_mensaje_js( 'cdb_ajax_bares_sin_resultados' ),
+            'cdb_ajax_disponibilidad_actualizada' => cdb_form_get_mensaje_js( 'cdb_ajax_disponibilidad_actualizada' ),
+            'cdb_ajax_error_disponibilidad' => cdb_form_get_mensaje_js( 'cdb_ajax_error_disponibilidad' ),
+            'cdb_ajax_estado_bar_actualizado' => cdb_form_get_mensaje_js( 'cdb_ajax_estado_bar_actualizado' ),
+            'cdb_ajax_error_estado_bar'     => cdb_form_get_mensaje_js( 'cdb_ajax_error_estado_bar' ),
+            'cdb_ajax_error_comunicacion'   => cdb_form_get_mensaje_js( 'cdb_ajax_error_comunicacion' ),
+            'cdb_ajax_error_anio_cifras'    => cdb_form_get_mensaje_js( 'cdb_ajax_error_anio_cifras' ),
+            'cdb_ajax_error_nombre_invalido' => cdb_form_get_mensaje_js( 'cdb_ajax_error_nombre_invalido' ),
+            'cdb_ajax_error_posicion_invalida' => cdb_form_get_mensaje_js( 'cdb_ajax_error_posicion_invalida' ),
+            'cdb_ajax_error_bar_invalido'   => cdb_form_get_mensaje_js( 'cdb_ajax_error_bar_invalido' ),
+            'cdb_ajax_error_anio_invalido'  => cdb_form_get_mensaje_js( 'cdb_ajax_error_anio_invalido' ),
+            'cdb_ajax_error_zona_invalida'  => cdb_form_get_mensaje_js( 'cdb_ajax_error_zona_invalida' ),
+        )
+    );
 }
 add_action( 'wp_enqueue_scripts', 'cdb_form_public_enqueue' );


### PR DESCRIPTION
## Summary
- add helper `cdb_form_get_mensaje_js` and new default strings for numerous AJAX alerts
- expose configurable messages to JavaScript via `wp_localize_script`
- replace hard-coded alert messages with `window.alert(cdbMsgs.key)`
- document new message keys in README

## Testing
- `php -l includes/messages.php`
- `php -l public/enqueue.php`
- `grep -R "alert('" assets/js | wc -l`
- `grep -R "console.log('" assets/js | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_688e892c01ec83279db8048950c71b3b