### PR TITLE
Add i18n support for configurable messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,27 @@ Para más información consulta la carpeta `docs/`.
 ## Internacionalización
 
 El plugin carga las traducciones desde la carpeta `languages` mediante `load_plugin_textdomain()` al iniciarse. Para generar el archivo `cdb-form.pot` se utilizan las funciones de internacionalización de WordPress en todo el código.
+
+## Traducciones
+
+Para crear archivos de traducción personalizados sigue estos pasos:
+
+1. Genera el archivo `.pot` con la utilidad de WP-CLI:
+
+   ```bash
+   wp i18n make-pot . languages/cdb-form.pot
+   ```
+
+2. Crea un archivo `.po` para tu idioma a partir del `.pot` (ejemplo para español de España):
+
+   ```bash
+   msginit --locale=es_ES --input=languages/cdb-form.pot --output-file=languages/es_ES.po
+   ```
+
+3. Rellena los `msgstr` del `.po` y compílalo a `.mo`:
+
+   ```bash
+   msgfmt languages/es_ES.po -o languages/es_ES.mo
+   ```
+
+Coloca los archivos generados en la carpeta `languages` para que WordPress los cargue automáticamente.

--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -256,6 +256,8 @@ function cdb_form_config_mensajes_page() {
                     ),
                     ''
                 );
+                $clave_i18n      = $placeholder_map[ $datos['text_option'] ] ?? $datos['text_option'];
+                $traduccion_i18n = cdb_form_get_mensaje_i18n( $clave_i18n );
                 $tipo       = get_option( $datos['color_option'], 'aviso' );
                 $datos_tipo = $tipos_color[ $tipo ] ?? array();
                 $clase      = $datos_tipo['class'] ?? '';
@@ -275,6 +277,7 @@ function cdb_form_config_mensajes_page() {
                         <label><?php esc_html_e( 'Frase secundaria', 'cdb-form' ); ?></label>
                         <textarea class="large-text" rows="2" name="<?php echo esc_attr( $sec_opt ); ?>" data-role="secundario"><?php echo esc_textarea( $secundario ); ?></textarea>
                         <p class="description"><?php echo esc_html( $datos['description'] ); ?></p>
+                        <p class="description"><em><?php esc_html_e( 'Traducción actual:', 'cdb-form' ); ?></em> <?php echo esc_html( $traduccion_i18n ); ?></p>
                         <label><?php esc_html_e( 'Tipo/Color', 'cdb-form' ); ?></label>
                         <select name="<?php echo esc_attr( $datos['color_option'] ); ?>">
                             <?php foreach ( $tipos_color as $slug => $info ) : ?>

--- a/assets/js/frontend-scripts.js
+++ b/assets/js/frontend-scripts.js
@@ -1,4 +1,9 @@
 jQuery(document).ready(function($) {
+    function cdbGetMsg(key){
+        var src = (typeof cdbMsgs_i18n !== 'undefined' && cdbMsgs_i18n[key]) ? cdbMsgs_i18n[key] :
+                  (typeof cdbMsgs !== 'undefined' && cdbMsgs[key] ? cdbMsgs[key] : '');
+        return src.replace('|', ' ');
+    }
     // 🔹 Manejo de actualización de disponibilidad del empleado
     $('#cdb-update-disponibilidad').on('submit', function(e) {
         e.preventDefault();
@@ -17,15 +22,15 @@ jQuery(document).ready(function($) {
                 console.log("Respuesta AJAX (Empleado):", response); // Depuración en consola
 
                 if (response.success) {
-                    window.alert(cdbMsgs.cdb_ajax_disponibilidad_actualizada);
+                    window.alert(cdbGetMsg('cdb_ajax_disponibilidad_actualizada'));
                     location.reload();
                 } else {
-                    window.alert(response.data.message || cdbMsgs.cdb_ajax_error_disponibilidad);
+                    window.alert(response.data.message || cdbGetMsg('cdb_ajax_error_disponibilidad'));
                 }
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.error("Error AJAX (Empleado):", textStatus, errorThrown);
-                window.alert(cdbMsgs.cdb_ajax_error_disponibilidad);
+                window.alert(cdbGetMsg('cdb_ajax_error_disponibilidad'));
             }
         });
     });
@@ -48,15 +53,15 @@ jQuery(document).ready(function($) {
                 console.log("Respuesta AJAX (Bar):", response); // Depuración en consola
 
                 if (response.success) {
-                    window.alert(cdbMsgs.cdb_ajax_estado_bar_actualizado);
+                    window.alert(cdbGetMsg('cdb_ajax_estado_bar_actualizado'));
                     location.reload();
                 } else {
-                    window.alert(response.data.message || cdbMsgs.cdb_ajax_error_estado_bar);
+                    window.alert(response.data.message || cdbGetMsg('cdb_ajax_error_estado_bar'));
                 }
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.error("Error AJAX (Bar):", textStatus, errorThrown);
-                window.alert(cdbMsgs.cdb_ajax_error_estado_bar);
+                window.alert(cdbGetMsg('cdb_ajax_error_estado_bar'));
             }
         });
     });
@@ -83,7 +88,7 @@ jQuery(document).ready(function($) {
             if (spinner) spinner.style.display = 'none';
         }).fail(function(jqXHR){
             if (spinner) spinner.style.display = 'none';
-            window.alert(cdbMsgs.cdb_ajax_error_comunicacion);
+            window.alert(cdbGetMsg('cdb_ajax_error_comunicacion'));
             console.error('cdb_buscar_empleados AJAX fail', jqXHR);
         });
     }
@@ -216,23 +221,23 @@ jQuery(document).ready(function($) {
 
         function validarFiltros(){
             if(anioInput.value && !/^[0-9]{4}$/.test(anioInput.value)){
-                window.alert(cdbMsgs.cdb_ajax_error_anio_cifras);
+                window.alert(cdbGetMsg('cdb_ajax_error_anio_cifras'));
                 return false;
             }
             if(nombreInput.value && !nombreInput.dataset.valid){
-                window.alert(cdbMsgs.cdb_ajax_error_nombre_invalido);
+                window.alert(cdbGetMsg('cdb_ajax_error_nombre_invalido'));
                 return false;
             }
             if(posInput.value && !posInput.dataset.valid){
-                window.alert(cdbMsgs.cdb_ajax_error_posicion_invalida);
+                window.alert(cdbGetMsg('cdb_ajax_error_posicion_invalida'));
                 return false;
             }
             if(barInput.value && !barInput.dataset.valid){
-                window.alert(cdbMsgs.cdb_ajax_error_bar_invalido);
+                window.alert(cdbGetMsg('cdb_ajax_error_bar_invalido'));
                 return false;
             }
             if(anioInput.value && !anioInput.dataset.valid){
-                window.alert(cdbMsgs.cdb_ajax_error_anio_invalido);
+                window.alert(cdbGetMsg('cdb_ajax_error_anio_invalido'));
                 return false;
             }
             return true;
@@ -276,7 +281,7 @@ jQuery(document).ready(function($) {
             if (spinner) spinner.style.display = 'none';
         }).fail(function(jqXHR){
             if (spinner) spinner.style.display = 'none';
-            window.alert(cdbMsgs.cdb_ajax_error_comunicacion);
+            window.alert(cdbGetMsg('cdb_ajax_error_comunicacion'));
             console.error('cdb_buscar_bares AJAX fail', jqXHR);
         });
     }
@@ -359,15 +364,15 @@ jQuery(document).ready(function($) {
 
         function validarFiltrosBares(){
             if(aperturaInput.value && !/^[0-9]{4}$/.test(aperturaInput.value)){
-                window.alert(cdbMsgs.cdb_ajax_error_anio_cifras);
+                window.alert(cdbGetMsg('cdb_ajax_error_anio_cifras'));
                 return false;
             }
             if(bNombreInput.value && !bNombreInput.dataset.valid){
-                window.alert(cdbMsgs.cdb_ajax_error_bar_invalido);
+                window.alert(cdbGetMsg('cdb_ajax_error_bar_invalido'));
                 return false;
             }
             if(zonaInput.value && !zonaInput.dataset.valid){
-                window.alert(cdbMsgs.cdb_ajax_error_zona_invalida);
+                window.alert(cdbGetMsg('cdb_ajax_error_zona_invalida'));
                 return false;
             }
             return true;

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -20,30 +20,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Valores por defecto de mensajes y avisos.
 $cdb_form_defaults = array(
-    'cdb_aviso_sin_puntuacion'     => __( 'Puntuación gráfica no disponible.| Añade más valoraciones para generar tu gráfico.', 'cdb-form' ),
-    'cdb_empleado_no_encontrado'   => __( 'Empleado no encontrado.| Crea primero tu perfil de empleado para continuar.', 'cdb-form' ),
-    'cdb_experiencia_sin_perfil'   => __( 'Para registrar experiencia debes crear tu perfil.| Completa tu información de empleado y vuelve aquí.', 'cdb-form' ),
-    'cdb_bares_sin_resultados'     => __( 'No hay bares que coincidan con tu búsqueda.| Ajusta filtros o prueba con otro término.', 'cdb-form' ),
-    'cdb_empleados_vacio'          => __( 'Aún no hay empleados registrados.| ¡Sé el primero en unirte al proyecto!', 'cdb-form' ),
-    'cdb_empleados_sin_resultados' => __( 'Sin coincidencias para tu búsqueda.| Modifica los criterios e inténtalo de nuevo.', 'cdb-form' ),
-    'cdb_acceso_sin_login'         => __( 'Debes iniciar sesión para acceder.| Inicia sesión o regístrate para continuar.', 'cdb-form' ),
-    'cdb_acceso_sin_permisos'      => __( 'No tienes permisos para ver este contenido.| Contacta con un admin si crees que es un error.', 'cdb-form' ),
-    'cdb_ajax_exito_empleado'      => __( 'Empleado creado correctamente.| El perfil se ha guardado sin problemas.', 'cdb-form' ),
-    'cdb_ajax_error_empleado'      => __( 'Error al crear empleado.| Inténtalo de nuevo más tarde.', 'cdb-form' ),
-    'cdb_ajax_exito_experiencia'   => __( 'Experiencia registrada.| Se ha guardado la experiencia.', 'cdb-form' ),
-    'cdb_ajax_empleados_sin_resultados' => __( 'Sin resultados.| No hay empleados que coincidan con tu búsqueda.', 'cdb-form' ),
-    'cdb_ajax_bares_sin_resultados'     => __( 'Sin resultados.| No hay bares que coincidan con tu búsqueda.', 'cdb-form' ),
-    'cdb_ajax_disponibilidad_actualizada' => __( 'Disponibilidad actualizada correctamente.| Los datos se han guardado.', 'cdb-form' ),
-    'cdb_ajax_error_disponibilidad' => __( 'Hubo un problema al actualizar la disponibilidad.| Inténtalo de nuevo más tarde.', 'cdb-form' ),
-    'cdb_ajax_estado_bar_actualizado' => __( 'Estado del bar actualizado correctamente.| Los datos se han guardado.', 'cdb-form' ),
-    'cdb_ajax_error_estado_bar'    => __( 'Hubo un problema al actualizar el estado del bar.| Inténtalo de nuevo más tarde.', 'cdb-form' ),
-    'cdb_ajax_error_comunicacion'  => __( 'Error de comunicación.| No se pudo contactar con el servidor.', 'cdb-form' ),
-    'cdb_ajax_error_anio_cifras'   => __( 'El año debe tener 4 cifras.| Introduce un año válido.', 'cdb-form' ),
-    'cdb_ajax_error_nombre_invalido' => __( 'Selecciona un nombre válido.| Elige una opción de la lista.', 'cdb-form' ),
-    'cdb_ajax_error_posicion_invalida' => __( 'Selecciona una posición válida.| Usa la ayuda de autocompletado.', 'cdb-form' ),
-    'cdb_ajax_error_bar_invalido'  => __( 'Selecciona un bar válido.| Usa la ayuda de autocompletado.', 'cdb-form' ),
-    'cdb_ajax_error_anio_invalido' => __( 'Selecciona un año válido.| Usa un formato de cuatro cifras.', 'cdb-form' ),
-    'cdb_ajax_error_zona_invalida' => __( 'Selecciona una zona válida.| Elige una opción de la lista.', 'cdb-form' ),
+    'cdb_aviso_sin_puntuacion'     => __( 'Puntuación gráfica no disponible.', 'cdb-form' ) . '|' . __( 'Añade más valoraciones para generar tu gráfico.', 'cdb-form' ),
+    'cdb_empleado_no_encontrado'   => __( 'Empleado no encontrado.', 'cdb-form' ) . '|' . __( 'Crea primero tu perfil de empleado para continuar.', 'cdb-form' ),
+    'cdb_experiencia_sin_perfil'   => __( 'Para registrar experiencia debes crear tu perfil.', 'cdb-form' ) . '|' . __( 'Completa tu información de empleado y vuelve aquí.', 'cdb-form' ),
+    'cdb_bares_sin_resultados'     => __( 'No hay bares que coincidan con tu búsqueda.', 'cdb-form' ) . '|' . __( 'Ajusta filtros o prueba con otro término.', 'cdb-form' ),
+    'cdb_empleados_vacio'          => __( 'Aún no hay empleados registrados.', 'cdb-form' ) . '|' . __( '¡Sé el primero en unirte al proyecto!', 'cdb-form' ),
+    'cdb_empleados_sin_resultados' => __( 'Sin coincidencias para tu búsqueda.', 'cdb-form' ) . '|' . __( 'Modifica los criterios e inténtalo de nuevo.', 'cdb-form' ),
+    'cdb_acceso_sin_login'         => __( 'Debes iniciar sesión para acceder.', 'cdb-form' ) . '|' . __( 'Inicia sesión o regístrate para continuar.', 'cdb-form' ),
+    'cdb_acceso_sin_permisos'      => __( 'No tienes permisos para ver este contenido.', 'cdb-form' ) . '|' . __( 'Contacta con un admin si crees que es un error.', 'cdb-form' ),
+    'cdb_ajax_exito_empleado'      => __( 'Empleado creado correctamente.', 'cdb-form' ) . '|' . __( 'El perfil se ha guardado sin problemas.', 'cdb-form' ),
+    'cdb_ajax_error_empleado'      => __( 'Error al crear empleado.', 'cdb-form' ) . '|' . __( 'Inténtalo de nuevo más tarde.', 'cdb-form' ),
+    'cdb_ajax_exito_experiencia'   => __( 'Experiencia registrada.', 'cdb-form' ) . '|' . __( 'Se ha guardado la experiencia.', 'cdb-form' ),
+    'cdb_ajax_empleados_sin_resultados' => __( 'Sin resultados.', 'cdb-form' ) . '|' . __( 'No hay empleados que coincidan con tu búsqueda.', 'cdb-form' ),
+    'cdb_ajax_bares_sin_resultados'     => __( 'Sin resultados.', 'cdb-form' ) . '|' . __( 'No hay bares que coincidan con tu búsqueda.', 'cdb-form' ),
+    'cdb_ajax_disponibilidad_actualizada' => __( 'Disponibilidad actualizada correctamente.', 'cdb-form' ) . '|' . __( 'Los datos se han guardado.', 'cdb-form' ),
+    'cdb_ajax_error_disponibilidad' => __( 'Hubo un problema al actualizar la disponibilidad.', 'cdb-form' ) . '|' . __( 'Inténtalo de nuevo más tarde.', 'cdb-form' ),
+    'cdb_ajax_estado_bar_actualizado' => __( 'Estado del bar actualizado correctamente.', 'cdb-form' ) . '|' . __( 'Los datos se han guardado.', 'cdb-form' ),
+    'cdb_ajax_error_estado_bar'    => __( 'Hubo un problema al actualizar el estado del bar.', 'cdb-form' ) . '|' . __( 'Inténtalo de nuevo más tarde.', 'cdb-form' ),
+    'cdb_ajax_error_comunicacion'  => __( 'Error de comunicación.', 'cdb-form' ) . '|' . __( 'No se pudo contactar con el servidor.', 'cdb-form' ),
+    'cdb_ajax_error_anio_cifras'   => __( 'El año debe tener 4 cifras.', 'cdb-form' ) . '|' . __( 'Introduce un año válido.', 'cdb-form' ),
+    'cdb_ajax_error_nombre_invalido' => __( 'Selecciona un nombre válido.', 'cdb-form' ) . '|' . __( 'Elige una opción de la lista.', 'cdb-form' ),
+    'cdb_ajax_error_posicion_invalida' => __( 'Selecciona una posición válida.', 'cdb-form' ) . '|' . __( 'Usa la ayuda de autocompletado.', 'cdb-form' ),
+    'cdb_ajax_error_bar_invalido'  => __( 'Selecciona un bar válido.', 'cdb-form' ) . '|' . __( 'Usa la ayuda de autocompletado.', 'cdb-form' ),
+    'cdb_ajax_error_anio_invalido' => __( 'Selecciona un año válido.', 'cdb-form' ) . '|' . __( 'Usa un formato de cuatro cifras.', 'cdb-form' ),
+    'cdb_ajax_error_zona_invalida' => __( 'Selecciona una zona válida.', 'cdb-form' ) . '|' . __( 'Elige una opción de la lista.', 'cdb-form' ),
     // …añade aquí cualquier clave nueva que surja
 );
 
@@ -275,12 +275,24 @@ function cdb_form_get_mensaje_js( $clave ) {
         $secundario = $parts[1] ?? '';
     }
 
-    $mensaje = $texto;
+    $mensaje = trim( wp_strip_all_tags( $texto ) );
     if ( '' !== $secundario ) {
-        $mensaje .= ' ' . $secundario;
+        $mensaje .= '|' . trim( wp_strip_all_tags( $secundario ) );
     }
 
-    return trim( wp_strip_all_tags( $mensaje ) );
+    return $mensaje;
+}
+
+/**
+ * Devuelve un mensaje traducido según el idioma actual de WordPress.
+ *
+ * @param string $key Clave del mensaje.
+ * @return string Mensaje traducido.
+ */
+function cdb_form_get_mensaje_i18n( $key ) {
+    $msg = cdb_form_get_mensaje_js( $key );
+    list( $dest, $sec ) = array_pad( explode( '|', $msg, 2 ), 2, '' );
+    return trim( sprintf( '%s %s', __( $dest, 'cdb-form' ), __( $sec, 'cdb-form' ) ) );
 }
 
 /**

--- a/languages/es_ES.po
+++ b/languages/es_ES.po
@@ -1,21 +1,21 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Spanish translations for PACKAGE package.
+# Copyright (C) 2025 THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Automatically generated, 2025.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-02 22:11+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2025-08-02 22:11+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: admin/config-mensajes.php:17 admin/config-mensajes.php:18
 #: admin/config-mensajes.php:211

--- a/public/enqueue.php
+++ b/public/enqueue.php
@@ -82,5 +82,28 @@ function cdb_form_public_enqueue() {
             'cdb_ajax_error_zona_invalida'  => cdb_form_get_mensaje_js( 'cdb_ajax_error_zona_invalida' ),
         )
     );
+
+    wp_localize_script(
+        'cdb-form-frontend-script',
+        'cdbMsgs_i18n',
+        array(
+            'cdb_ajax_exito_empleado'       => cdb_form_get_mensaje_i18n( 'cdb_ajax_exito_empleado' ),
+            'cdb_ajax_error_empleado'       => cdb_form_get_mensaje_i18n( 'cdb_ajax_error_empleado' ),
+            'cdb_ajax_exito_experiencia'    => cdb_form_get_mensaje_i18n( 'cdb_ajax_exito_experiencia' ),
+            'cdb_ajax_empleados_sin_resultados' => cdb_form_get_mensaje_i18n( 'cdb_ajax_empleados_sin_resultados' ),
+            'cdb_ajax_bares_sin_resultados'     => cdb_form_get_mensaje_i18n( 'cdb_ajax_bares_sin_resultados' ),
+            'cdb_ajax_disponibilidad_actualizada' => cdb_form_get_mensaje_i18n( 'cdb_ajax_disponibilidad_actualizada' ),
+            'cdb_ajax_error_disponibilidad' => cdb_form_get_mensaje_i18n( 'cdb_ajax_error_disponibilidad' ),
+            'cdb_ajax_estado_bar_actualizado' => cdb_form_get_mensaje_i18n( 'cdb_ajax_estado_bar_actualizado' ),
+            'cdb_ajax_error_estado_bar'     => cdb_form_get_mensaje_i18n( 'cdb_ajax_error_estado_bar' ),
+            'cdb_ajax_error_comunicacion'   => cdb_form_get_mensaje_i18n( 'cdb_ajax_error_comunicacion' ),
+            'cdb_ajax_error_anio_cifras'    => cdb_form_get_mensaje_i18n( 'cdb_ajax_error_anio_cifras' ),
+            'cdb_ajax_error_nombre_invalido' => cdb_form_get_mensaje_i18n( 'cdb_ajax_error_nombre_invalido' ),
+            'cdb_ajax_error_posicion_invalida' => cdb_form_get_mensaje_i18n( 'cdb_ajax_error_posicion_invalida' ),
+            'cdb_ajax_error_bar_invalido'   => cdb_form_get_mensaje_i18n( 'cdb_ajax_error_bar_invalido' ),
+            'cdb_ajax_error_anio_invalido'  => cdb_form_get_mensaje_i18n( 'cdb_ajax_error_anio_invalido' ),
+            'cdb_ajax_error_zona_invalida'  => cdb_form_get_mensaje_i18n( 'cdb_ajax_error_zona_invalida' ),
+        )
+    );
 }
 add_action( 'wp_enqueue_scripts', 'cdb_form_public_enqueue' );


### PR DESCRIPTION
## Summary
- split default messages into translatable parts and add helper to fetch localized text
- show current translation in admin message editor
- expose translated strings to JS and use them with fallback

## Testing
- `php -l includes/messages.php`
- `php -l admin/config-mensajes.php`
- `php -l public/enqueue.php`
- `node --check assets/js/frontend-scripts.js`
- `wp i18n make-pot . languages/cdb-form.pot` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e8bbb613c83279bffc5ab268dae3e