### PR TITLE
Automate POT generation and load textdomain on init

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Build plugin
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run pot
+      - name: Build zip
+        run: zip -r cdb-form.zip . -x '*.git*' 'node_modules/*'
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cdb-form
+          path: cdb-form.zip

--- a/README.md
+++ b/README.md
@@ -116,3 +116,11 @@ Para crear archivos de traducción personalizados sigue estos pasos:
    ```
 
 Coloca los archivos generados en la carpeta `languages` para que WordPress los cargue automáticamente.
+
+## Actualización del POT
+
+Para regenerar el archivo `cdb-form.pot` ejecuta:
+
+```bash
+npm install && npm run pot
+```

--- a/cdb-form.php
+++ b/cdb-form.php
@@ -21,12 +21,14 @@ define( 'CDB_FORM_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CDB_FORM_URL', plugin_dir_url( __FILE__ ) );
 
 /**
- * Carga el archivo de traducciones del plugin.
+ * Carga las traducciones del plugin.
  */
-function cdb_form_load_textdomain() {
-    load_plugin_textdomain( 'cdb-form', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-}
-add_action( 'plugins_loaded', 'cdb_form_load_textdomain' );
+add_action(
+    'init',
+    function () {
+        load_plugin_textdomain( 'cdb-form', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    }
+);
 
 /*---------------------------------------------------------------
  * 2. CARGA OPCIONAL DEL PLUGIN cdb-bar (SI EXISTE)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdb-form",
+  "private": true,
+  "scripts": {
+    "pot": "wp i18n make-pot . languages/cdb-form.pot --exclude=node_modules,tests || vendor/bin/wp i18n make-pot . languages/cdb-form.pot --exclude=node_modules,tests"
+  }
+}


### PR DESCRIPTION
## Summary
- load plugin translations at `init`
- document POT regeneration and add npm script with WP-CLI fallback
- build workflow runs `npm run pot` before zipping

## Testing
- `wp i18n make-pot . /tmp/test.pot` *(fails: command not found)*
- `wp eval "echo __('Gracias por colaborar con Proyecto CdB.', 'cdb-form');"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e8f6984e88327b5eaf14850fe7c0a