### PR TITLE
Improve accessibility and cleanup unused code

### DIFF
--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -34,3 +34,16 @@
 .cdb-tipo-color-row input[type="text"] { width:120px; }
 .cdb-tipo-color-row .cdb-color-swatch { width:20px; height:20px; }
 .cdb-tipo-color-row.deleting { opacity:0.5; }
+
+/* Utilidad de acceso solo para lectores de pantalla */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/assets/js/frontend-scripts.js
+++ b/assets/js/frontend-scripts.js
@@ -11,7 +11,6 @@ jQuery(document).ready(function($) {
         var form = $(this);
         var formData = form.serialize();
 
-        console.log("Datos enviados (Empleado):", formData); // Depuración en consola
 
         $.ajax({
             type: 'POST',
@@ -19,7 +18,6 @@ jQuery(document).ready(function($) {
             data: formData + '&action=cdb_actualizar_disponibilidad',
             dataType: 'json',
             success: function(response) {
-                console.log("Respuesta AJAX (Empleado):", response); // Depuración en consola
 
                 if (response.success) {
                     window.alert(cdbGetMsg('cdb_ajax_disponibilidad_actualizada'));
@@ -29,7 +27,6 @@ jQuery(document).ready(function($) {
                 }
             },
             error: function(jqXHR, textStatus, errorThrown) {
-                console.error("Error AJAX (Empleado):", textStatus, errorThrown);
                 window.alert(cdbGetMsg('cdb_ajax_error_disponibilidad'));
             }
         });
@@ -42,7 +39,6 @@ jQuery(document).ready(function($) {
         var form = $(this);
         var formData = form.serialize();
 
-        console.log("Datos enviados (Bar):", formData); // Depuración en consola
 
         $.ajax({
             type: 'POST',
@@ -50,7 +46,6 @@ jQuery(document).ready(function($) {
             data: formData + '&action=cdb_actualizar_estado_bar',
             dataType: 'json',
             success: function(response) {
-                console.log("Respuesta AJAX (Bar):", response); // Depuración en consola
 
                 if (response.success) {
                     window.alert(cdbGetMsg('cdb_ajax_estado_bar_actualizado'));
@@ -60,7 +55,6 @@ jQuery(document).ready(function($) {
                 }
             },
             error: function(jqXHR, textStatus, errorThrown) {
-                console.error("Error AJAX (Bar):", textStatus, errorThrown);
                 window.alert(cdbGetMsg('cdb_ajax_error_estado_bar'));
             }
         });
@@ -89,7 +83,6 @@ jQuery(document).ready(function($) {
         }).fail(function(jqXHR){
             if (spinner) spinner.style.display = 'none';
             window.alert(cdbGetMsg('cdb_ajax_error_comunicacion'));
-            console.error('cdb_buscar_empleados AJAX fail', jqXHR);
         });
     }
 
@@ -145,9 +138,7 @@ jQuery(document).ready(function($) {
                 nonce: cdb_form_ajax.nonce,
                 tipo: tipo,
                 term: termino
-            }, callback).fail(function(jqXHR){
-                console.error('cdb_sugerencias AJAX fail', jqXHR);
-            });
+            }, callback);
         }
 
         var posSugs = [], barSugs = [];
@@ -253,7 +244,6 @@ jQuery(document).ready(function($) {
     if (initResult === false) {
         document.addEventListener('awesomplete-loaded', initBusqueda, { once: true });
         setTimeout(initBusqueda, 50);
-        setTimeout(function(){ if(!window.Awesomplete){ console.error('Awesomplete failed to load'); } }, 5000);
     }
 
     // ---- Buscador de bares ----
@@ -282,7 +272,6 @@ jQuery(document).ready(function($) {
         }).fail(function(jqXHR){
             if (spinner) spinner.style.display = 'none';
             window.alert(cdbGetMsg('cdb_ajax_error_comunicacion'));
-            console.error('cdb_buscar_bares AJAX fail', jqXHR);
         });
     }
 
@@ -328,9 +317,7 @@ jQuery(document).ready(function($) {
                 nonce: cdb_form_ajax.nonce,
                 tipo: t,
                 term: term
-            }, cb).fail(function(jqXHR){
-                console.error('cdb_sugerencias AJAX fail', jqXHR);
-            });
+            }, cb);
         }
 
         var zonaS = [], barS = [];
@@ -387,7 +374,6 @@ jQuery(document).ready(function($) {
     if (initBars === false) {
         document.addEventListener('awesomplete-loaded', initBusquedaBares, { once: true });
         setTimeout(initBusquedaBares, 50);
-        setTimeout(function(){ if(!window.Awesomplete){ console.error('Awesomplete failed to load for buscador de bares'); } }, 5000);
     }
 });
 

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -224,7 +224,7 @@ function cdb_form_get_mensaje( $clave, $tipo = 'aviso' ) {
     $tipo_guardado = get_option( $color_option, $tipo );
     $clase         = cdb_form_get_tipo_color_class( $tipo_guardado );
 
-    $html  = '<div class="cdb-aviso ' . esc_attr( $clase ) . '">';
+    $html  = '<div class="cdb-aviso ' . esc_attr( $clase ) . '" role="alert">';
     $html .= '<strong class="cdb-mensaje-destacado">' . wp_kses_post( $texto ) . '</strong>';
     $html .= '</div>';
 
@@ -357,7 +357,7 @@ function cdb_form_render_mensaje( $text_option, $color_option, $default_text, $d
         }
     }
 
-    $html  = '<div class="cdb-aviso ' . esc_attr( $clase ) . '">';
+    $html  = '<div class="cdb-aviso ' . esc_attr( $clase ) . '" role="alert">';
     $html .= '<strong class="cdb-mensaje-destacado">' . wp_kses_post( $texto ) . '</strong>';
 
     if ( '' !== $secundario ) {

--- a/public/form-bar.php
+++ b/public/form-bar.php
@@ -51,8 +51,8 @@ function cdb_form_bar() {
             <option value="Traspaso" <?php selected($estado_actual, 'Traspaso'); ?>><?php esc_html_e( 'Traspaso', 'cdb-form' ); ?></option>
             <option value="Desconocido" <?php selected($estado_actual, 'Desconocido'); ?>><?php esc_html_e( 'Desconocido', 'cdb-form' ); ?></option>
         </select>
-        <input type="hidden" name="bar_id" value="<?php echo esc_attr($bar_id); ?>">
-        <input type="hidden" name="security" value="<?php echo wp_create_nonce('cdb_form_nonce'); ?>">
+        <input type="hidden" name="bar_id" value="<?php echo esc_attr($bar_id); ?>" aria-hidden="true">
+        <input type="hidden" name="security" value="<?php echo wp_create_nonce('cdb_form_nonce'); ?>" aria-hidden="true">
         <button type="submit"><?php esc_html_e( 'Actualizar', 'cdb-form' ); ?></button>
     </form>
     <p id="cdb-response-message-bar" style="color: green;"></p>

--- a/templates/busqueda-bares-table.php
+++ b/templates/busqueda-bares-table.php
@@ -4,12 +4,13 @@
     ); ?>
 <?php else : ?>
 <table class="cdb-busqueda-table">
+    <caption><?php esc_html_e( 'Resultados de búsqueda de bares', 'cdb-form' ); ?></caption>
     <thead>
         <tr>
-            <th><?php esc_html_e( 'Puntuación', 'cdb-form' ); ?></th>
-            <th><?php esc_html_e( 'Nombre', 'cdb-form' ); ?></th>
-            <th><?php esc_html_e( 'Zona', 'cdb-form' ); ?></th>
-            <th><?php esc_html_e( 'Año', 'cdb-form' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Puntuación', 'cdb-form' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Nombre', 'cdb-form' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Zona', 'cdb-form' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Año', 'cdb-form' ); ?></th>
         </tr>
     </thead>
     <tbody>

--- a/templates/busqueda-empleados-table.php
+++ b/templates/busqueda-empleados-table.php
@@ -4,13 +4,14 @@
     ); ?>
 <?php else : ?>
 <table class="cdb-busqueda-table">
+    <caption><?php esc_html_e( 'Resultados de búsqueda de empleados', 'cdb-form' ); ?></caption>
     <thead>
         <tr>
-            <th><?php esc_html_e( 'Puntuación', 'cdb-form' ); ?></th>
-            <th><?php esc_html_e( 'Nombre', 'cdb-form' ); ?></th>
-            <th><?php esc_html_e( 'Posiciones', 'cdb-form' ); ?></th>
-            <th><?php esc_html_e( 'Bares', 'cdb-form' ); ?></th>
-            <th><?php esc_html_e( 'Año', 'cdb-form' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Puntuación', 'cdb-form' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Nombre', 'cdb-form' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Posiciones', 'cdb-form' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Bares', 'cdb-form' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Año', 'cdb-form' ); ?></th>
         </tr>
     </thead>
     <tbody>

--- a/templates/form-empleado-template.php
+++ b/templates/form-empleado-template.php
@@ -80,7 +80,7 @@ $cdb_alignment             = isset($disenio['alignment']) ? $disenio['alignment'
     <form id="cdb-form-empleado" method="post">
         <?php wp_nonce_field('cdb_form_nonce', 'security'); ?>
 
-        <input type="hidden" name="empleado_id" value="<?php echo esc_attr($empleado_id); ?>">
+        <input type="hidden" name="empleado_id" value="<?php echo esc_attr($empleado_id); ?>" aria-hidden="true">
 
         <label for="nombre"><?php esc_html_e( 'Nombre:', 'cdb-form' ); ?></label>
         <input type="text" id="nombre" name="nombre" value="<?php echo esc_attr($empleado_nombre); ?>" required>

--- a/templates/form-experiencia-template.php
+++ b/templates/form-experiencia-template.php
@@ -32,8 +32,6 @@ $posicion_actual = '';
 
 $fecha_apertura = '';
 $fecha_cierre   = '';
-
-error_log("[DEBUG] Bar ID: {$bar_id_actual} - Apertura: {$fecha_apertura} - Cierre: {$fecha_cierre}");
 ?>
 
 <!-- Estilos visuales del formulario y la tabla de experiencia -->
@@ -182,13 +180,15 @@ error_log("[DEBUG] Bar ID: {$bar_id_actual} - Apertura: {$fecha_apertura} - Cier
                         <td>
                             <!-- Icono de “ojo” para ver el equipo, si existe -->
                             <?php if (!empty($exp->equipo_id)) : ?>
-                                <a class="cdb-btn-ver" href="<?php echo esc_url(get_permalink($exp->equipo_id)); ?>" title="Ver equipo">
-                                    <span class="dashicons dashicons-visibility"></span>
+                                <a class="cdb-btn-ver" href="<?php echo esc_url(get_permalink($exp->equipo_id)); ?>" title="<?php esc_attr_e( 'Ver equipo', 'cdb-form' ); ?>" aria-label="<?php esc_attr_e( 'Ver', 'cdb-form' ); ?>">
+                                    <span class="dashicons dashicons-visibility" aria-hidden="true"></span>
+                                    <span class="sr-only"><?php esc_html_e( 'Ver', 'cdb-form' ); ?></span>
                                 </a>
                             <?php endif; ?>
                             <!-- Botón de borrado de experiencia -->
-                            <button class="cdb-btn-borrar" data-exp-id="<?php echo esc_attr($exp->exp_id); ?>" title="Eliminar experiencia">
-                                <span class="dashicons dashicons-trash"></span>
+                            <button class="cdb-btn-borrar" data-exp-id="<?php echo esc_attr($exp->exp_id); ?>" title="<?php esc_attr_e( 'Eliminar experiencia', 'cdb-form' ); ?>" aria-label="<?php esc_attr_e( 'Eliminar', 'cdb-form' ); ?>">
+                                <span class="dashicons dashicons-trash" aria-hidden="true"></span>
+                                <span class="sr-only"><?php esc_html_e( 'Eliminar', 'cdb-form' ); ?></span>
                             </button>
                         </td>
                     </tr>
@@ -209,13 +209,13 @@ error_log("[DEBUG] Bar ID: {$bar_id_actual} - Apertura: {$fecha_apertura} - Cier
     <h2><?php esc_html_e( 'Actualizar Experiencia Laboral', 'cdb-form' ); ?></h2>
     <form id="cdb_experiencia_form">
         <!-- Acción para el AJAX -->
-        <input type="hidden" name="action" value="cdb_guardar_experiencia">
+        <input type="hidden" name="action" value="cdb_guardar_experiencia" aria-hidden="true">
         <!-- Nonce de seguridad -->
-        <input type="hidden" name="security" value="<?php echo wp_create_nonce('cdb_form_nonce'); ?>">
+        <input type="hidden" name="security" value="<?php echo wp_create_nonce('cdb_form_nonce'); ?>" aria-hidden="true">
         <!-- Se envía el empleado_id, aunque en el handler se obtiene de forma consistente -->
-        <input type="hidden" name="empleado_id" value="<?php echo esc_attr($empleado_id); ?>">
+        <input type="hidden" name="empleado_id" value="<?php echo esc_attr($empleado_id); ?>" aria-hidden="true">
         <!-- Campo oculto para vincular equipo si es necesario -->
-        <input type="hidden" name="relacionar_equipo" value="1">
+        <input type="hidden" name="relacionar_equipo" value="1" aria-hidden="true">
 
         <?php
         // 1) Obtener todos los bares y crear array para Autocomplete
@@ -247,7 +247,7 @@ error_log("[DEBUG] Bar ID: {$bar_id_actual} - Apertura: {$fecha_apertura} - Cier
             required
         >
         <!-- Hidden donde guardamos el ID real del bar seleccionado -->
-        <input type="hidden" id="bar_id" name="bar_id" value="">
+        <input type="hidden" id="bar_id" name="bar_id" value="" aria-hidden="true">
 
         <!-- Selección de Año (se actualizará dinámicamente) -->
         <label for="anio">Año:</label>


### PR DESCRIPTION
## Summary
- add accessible labels and hidden text to forms and action icons
- ensure search tables include captions and column scopes
- remove debug logging and add utility sr-only style

## Testing
- `php -l templates/form-empleado-template.php templates/form-experiencia-template.php public/form-bar.php templates/busqueda-bares-table.php templates/busqueda-empleados-table.php includes/messages.php`
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_688e92eabe808327b3fe07aee9099603