### PR TITLE
Reduce vertical spacing in alert messages

### DIFF
--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -22,7 +22,7 @@
 }
 
 .cdb-mensaje-secundario {
-    margin-top: 4px;
+    margin-top: 0;
 }
 
 /* Estilos utilizados únicamente en la pantalla de Configuración de Mensajes */


### PR DESCRIPTION
## Summary
- reduce margin between highlighted and secondary message lines in alerts

## Testing
- `npm test` (fails: Could not read package.json)
- `composer test` (fails: Command "test" is not defined)


------
https://chatgpt.com/codex/tasks/task_e_688f368d3b8083279004f2d7cc9f7c98