### PR TITLE
fix(avisos): elimina <br> extra entre frase destacada y secundaria

### DIFF
--- a/includes/messages.php
+++ b/includes/messages.php
@@ -361,7 +361,7 @@ function cdb_form_render_mensaje( $text_option, $color_option, $default_text, $d
     $html .= '<strong class="cdb-mensaje-destacado">' . wp_kses_post( $texto ) . '</strong>';
 
     if ( '' !== $secundario ) {
-        $html .= '<br><span class="cdb-mensaje-secundario">' . wp_kses_post( $secundario ) . '</span>';
+        $html .= '<span class="cdb-mensaje-secundario">' . wp_kses_post( $secundario ) . '</span>';
     }
 
     $html .= '</div>';


### PR DESCRIPTION
## Summary
- remove `<br>` between highlighted and secondary message in `includes/messages.php`

## Testing
- `php -l includes/messages.php`


------
https://chatgpt.com/codex/tasks/task_e_688f3b7402f0832784008f37768f7b35