### PR TITLE
fix(avisos): muestra frase secundaria en 'Empleado no encontrado' y 'Puntuación gráfica no disponible'

### DIFF
--- a/includes/messages.php
+++ b/includes/messages.php
@@ -216,9 +216,15 @@ function cdb_form_get_mensaje( $clave, $tipo = 'aviso' ) {
         cdb_form_get_option_compat( array( $color_option, $old_color_option ), null );
     }
 
-    $texto = get_option( $text_option, '' );
+    $texto      = get_option( $text_option, '' );
+    $secundario = get_option( $text_option . '_secundaria', '' );
     if ( '' === $texto ) {
         $texto = $cdb_form_defaults[ $clave ] ?? __( 'Aviso no configurado', 'cdb-form' );
+    }
+    if ( '' === $secundario && strpos( $texto, '|' ) !== false ) {
+        $parts      = array_map( 'trim', explode( '|', $texto, 2 ) );
+        $texto      = $parts[0];
+        $secundario = $parts[1] ?? '';
     }
 
     $tipo_guardado = get_option( $color_option, $tipo );
@@ -226,6 +232,9 @@ function cdb_form_get_mensaje( $clave, $tipo = 'aviso' ) {
 
     $html  = '<div class="cdb-aviso ' . esc_attr( $clase ) . '">';
     $html .= '<strong class="cdb-mensaje-destacado">' . wp_kses_post( $texto ) . '</strong>';
+    if ( '' !== $secundario ) {
+        $html .= '<span class="cdb-mensaje-secundario">' . wp_kses_post( $secundario ) . '</span>';
+    }
     $html .= '</div>';
 
     return $html;


### PR DESCRIPTION
## Summary
- Recupera la frase secundaria de cada aviso y evita dividir con `|` si el campo `_secundaria` está configurado
- Muestra la frase secundaria dentro de `<span class="cdb-mensaje-secundario">`

## Testing
- `php -l includes/messages.php`


------
https://chatgpt.com/codex/tasks/task_e_688f3f49a95c8327ace0bf59ea838ff3