### PR TITLE
Refactor profile missing notices

### DIFF
--- a/includes/messages.php
+++ b/includes/messages.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Valores por defecto de mensajes y avisos.
 $cdb_form_defaults = array(
     'cdb_aviso_sin_puntuacion'     => __( 'Puntuación gráfica no disponible.', 'cdb-form' ) . '|' . __( 'Añade más valoraciones para generar tu gráfico.', 'cdb-form' ),
-    'cdb_empleado_no_encontrado'   => __( 'Empleado no encontrado.', 'cdb-form' ) . '|' . __( 'Crea primero tu perfil de empleado para continuar.', 'cdb-form' ),
+    'cdb_empleado_no_encontrado'   => __( 'No encontramos tu perfil de empleado. Crea uno para unirte a tu equipo.', 'cdb-form' ),
     'cdb_experiencia_sin_perfil'   => __( 'Para registrar experiencia debes crear tu perfil.', 'cdb-form' ) . '|' . __( 'Completa tu información de empleado y vuelve aquí.', 'cdb-form' ),
     'cdb_bares_sin_resultados'     => __( 'No hay bares que coincidan con tu búsqueda.', 'cdb-form' ) . '|' . __( 'Ajusta filtros o prueba con otro término.', 'cdb-form' ),
     'cdb_empleados_vacio'          => __( 'Aún no hay empleados registrados.', 'cdb-form' ) . '|' . __( '¡Sé el primero en unirte al proyecto!', 'cdb-form' ),

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -129,12 +129,7 @@ function cdb_bienvenida_usuario_shortcode() {
             // Perfil existente: se muestra el panel del empleado.
             $output .= do_shortcode('[cdb_bienvenida_empleado]');
         } else {
-            // Sin perfil: mensaje configurable e invitación a crear uno.
-            $output .= cdb_form_render_mensaje(
-                'cdb_mensaje_bienvenida_usuario',
-                'cdb_color_bienvenida_usuario',
-                'No tienes un perfil de empleado registrado.'
-            );
+            // Sin perfil: se muestra el formulario de empleado, que ya incluye su propio aviso.
             $output .= do_shortcode('[cdb_form_empleado]');
         }
     }
@@ -350,19 +345,14 @@ function cdb_experiencia_shortcode() {
     }
 
     // 3) Comprobar que el usuario tenga un perfil de empleado publicado.
-    // Sin este perfil no puede registrar experiencias.
-    // La plantilla incluida volverá a validar este dato, generando comprobación redundante.
+    // Si falta, se muestra directamente el formulario de creación evitando avisos duplicados.
     $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
     if ($empleado_id === 0) {
-        return cdb_form_render_mensaje(
-            'cdb_mensaje_experiencia_sin_perfil',
-            'cdb_color_experiencia_sin_perfil',
-            __( 'No tienes un perfil de empleado registrado.', 'cdb-form' )
-        );
+        return do_shortcode('[cdb_form_empleado]');
     }
 
     // 4) Si pasa las verificaciones, se carga la plantilla del formulario.
-    // 'form-experiencia-template.php' incluye nuevamente validaciones de sesión y perfil.
+    // La plantilla validará nuevamente la sesión y mostrará los avisos necesarios.
     ob_start();
     include CDB_FORM_PATH . 'templates/form-experiencia-template.php';
     return ob_get_clean();


### PR DESCRIPTION
## Summary
- Consolidate default employee profile warning into a single combined message
- Simplify shortcodes to show employee form once when profile is missing and avoid duplicate notices

## Testing
- `php -l includes/messages.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_688f845d9638832792c42311c1e48af9