### PR TITLE
Migrar frase secundaria de mensajes

### DIFF
--- a/includes/messages.php
+++ b/includes/messages.php
@@ -214,6 +214,12 @@ function cdb_form_get_mensaje( $clave, $tipo = 'aviso' ) {
         // Migrar valores antiguos a las nuevas claves canónicas.
         cdb_form_get_option_compat( array( $text_option, $old_text_option ), null );
         cdb_form_get_option_compat( array( $color_option, $old_color_option ), null );
+
+        // Migrar la frase secundaria
+        cdb_form_get_option_compat(
+            array( $text_option . '_secundaria', $old_text_option . '_secundaria' ),
+            null
+        );
     }
 
     $texto      = get_option( $text_option, '' );


### PR DESCRIPTION
## Summary
- Migra opciones antiguas de frases secundarias al nuevo formato canónico en `cdb_form_get_mensaje`.
- Recupera y muestra frases secundarias migradas junto a los mensajes principales.

## Testing
- `php -l includes/messages.php`


------
https://chatgpt.com/codex/tasks/task_e_688f90ccb6d88327bd10229f7791a3d3