### PR TITLE
Añadir opción para mostrar/ocultar avisos

### DIFF
--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -157,7 +157,8 @@ function cdb_form_config_mensajes_page() {
     ) {
         // Guardar textos (principal y secundario) y tipo/color de cada mensaje
         foreach ( $mensajes as $datos ) {
-            $sec_opt = $datos['text_option'] . '_secundaria';
+            $sec_opt  = $datos['text_option'] . '_secundaria';
+            $show_opt = $datos['text_option'] . '_mostrar';
 
             if ( isset( $_POST[ $datos['text_option'] ] ) ) {
                 update_option( $datos['text_option'], wp_kses_post( $_POST[ $datos['text_option'] ] ) );
@@ -168,6 +169,10 @@ function cdb_form_config_mensajes_page() {
             if ( isset( $_POST[ $datos['color_option'] ] ) ) {
                 update_option( $datos['color_option'], sanitize_key( $_POST[ $datos['color_option'] ] ) );
             }
+
+            // Guardar estado de visibilidad (1 = mostrar, 0 = ocultar).
+            $mostrar = isset( $_POST[ $show_opt ] ) ? '1' : '0';
+            update_option( $show_opt, $mostrar );
         }
 
         // Guardar tipos/color
@@ -256,6 +261,8 @@ function cdb_form_config_mensajes_page() {
                     ),
                     ''
                 );
+                $show_opt  = $datos['text_option'] . '_mostrar';
+                $mostrar   = get_option( $show_opt, '1' );
                 $clave_i18n      = $placeholder_map[ $datos['text_option'] ] ?? $datos['text_option'];
                 $traduccion_i18n = cdb_form_get_mensaje_i18n( $clave_i18n );
                 $tipo       = get_option( $datos['color_option'], 'aviso' );
@@ -264,8 +271,8 @@ function cdb_form_config_mensajes_page() {
                 $color_hex  = $datos_tipo['color'] ?? '#000';
                 $text_hex   = $datos_tipo['text'] ?? cdb_form_get_contrasting_text_color( $color_hex );
                 ?>
-                <div class="cdb-config-mensaje" id="mensaje-<?php echo esc_attr( $id ); ?>">
-                    <strong><?php echo esc_html( $datos['label'] ); ?></strong>
+                <div class="cdb-config-mensaje<?php echo ( '1' !== $mostrar ) ? ' oculto' : ''; ?>" id="mensaje-<?php echo esc_attr( $id ); ?>">
+                    <strong><?php echo esc_html( $datos['label'] ); ?></strong> <span class="cdb-oculto-label"><?php esc_html_e( 'Oculto', 'cdb-form' ); ?></span>
                     <div class="cdb-mensaje-preview <?php echo esc_attr( $clase ); ?>" style="border-left-color: <?php echo esc_attr( $color_hex ); ?>; background-color: <?php echo esc_attr( $color_hex ); ?>; color: <?php echo esc_attr( $text_hex ); ?>;">
                         <strong class="cdb-mensaje-destacado"><?php echo wp_kses_post( $texto ); ?></strong>
                         <span class="cdb-mensaje-secundario" <?php if ( empty( $secundario ) ) echo 'style="display:none;"'; ?>><?php echo wp_kses_post( $secundario ); ?></span>
@@ -285,6 +292,7 @@ function cdb_form_config_mensajes_page() {
                             <?php endforeach; ?>
                         </select>
                         <p class="description"><?php esc_html_e( 'Clase CSS:', 'cdb-form' ); ?> <code class="cdb-clase-css"><?php echo esc_html( $clase ); ?></code></p>
+                        <label><input type="checkbox" name="<?php echo esc_attr( $show_opt ); ?>" value="1" <?php checked( $mostrar, '1' ); ?> data-role="mostrar" /> <?php esc_html_e( 'Mostrar aviso', 'cdb-form' ); ?></label>
                     </div>
                 </div>
             <?php endforeach; ?>

--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -28,6 +28,9 @@
 /* Estilos utilizados únicamente en la pantalla de Configuración de Mensajes */
 .cdb-config-mensaje { margin-bottom: 20px; }
 .cdb-config-mensaje.editing { border: 1px solid #2271b1; padding: 10px; }
+.cdb-config-mensaje.oculto .cdb-mensaje-preview { opacity:0.5; }
+.cdb-oculto-label { display:none; margin-left:8px; font-style:italic; }
+.cdb-config-mensaje.oculto .cdb-oculto-label { display:inline; }
 .cdb-mensaje-preview { padding: 8px 12px; margin-bottom: 8px; border-left: 4px solid transparent; }
 .cdb-color-swatch { display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:4px; vertical-align:middle; }
 .cdb-tipo-color-row { display:flex; align-items:center; gap:6px; margin-bottom:6px; }

--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -47,7 +47,13 @@ jQuery(document).ready(function($){
     });
 
     // Marcar fila como eliminada
-    $('#cdb-tipos-color').on('change', 'input[type="checkbox"]', function(){
+        $('#cdb-tipos-color').on('change', 'input[type="checkbox"]', function(){
         $(this).closest('.cdb-tipo-color-row').toggleClass('deleting', this.checked);
     });
+
+    // Controlar visibilidad de los avisos
+    $('.cdb-mensaje-edicion input[data-role="mostrar"]').on('change', function(){
+        var cont = $(this).closest('.cdb-config-mensaje');
+        cont.toggleClass('oculto', !this.checked);
+    }).trigger('change');
 });

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -207,6 +207,7 @@ function cdb_form_get_mensaje( $clave, $tipo = 'aviso' ) {
 
     $text_option  = $clave;
     $color_option = 'cdb_color_' . $clave;
+    $show_option  = $text_option . '_mostrar';
 
     if ( isset( $map[ $clave ] ) ) {
         $old_text_option  = $map[ $clave ];
@@ -215,15 +216,20 @@ function cdb_form_get_mensaje( $clave, $tipo = 'aviso' ) {
         cdb_form_get_option_compat( array( $text_option, $old_text_option ), null );
         cdb_form_get_option_compat( array( $color_option, $old_color_option ), null );
 
-        // Migrar la frase secundaria
+        // Migrar la frase secundaria y visibilidad
         cdb_form_get_option_compat(
             array( $text_option . '_secundaria', $old_text_option . '_secundaria' ),
+            null
+        );
+        cdb_form_get_option_compat(
+            array( $show_option, $old_text_option . '_mostrar' ),
             null
         );
     }
 
     $texto      = get_option( $text_option, '' );
     $secundario = get_option( $text_option . '_secundaria', '' );
+    $mostrar    = get_option( $show_option, '1' );
     if ( '' === $texto ) {
         $texto = $cdb_form_defaults[ $clave ] ?? __( 'Aviso no configurado', 'cdb-form' );
     }
@@ -231,6 +237,10 @@ function cdb_form_get_mensaje( $clave, $tipo = 'aviso' ) {
         $parts      = array_map( 'trim', explode( '|', $texto, 2 ) );
         $texto      = $parts[0];
         $secundario = $parts[1] ?? '';
+    }
+
+    if ( '0' === $mostrar ) {
+        return '';
     }
 
     $tipo_guardado = get_option( $color_option, $tipo );
@@ -293,6 +303,11 @@ function cdb_form_get_mensaje_js( $clave ) {
     $mensaje = trim( wp_strip_all_tags( $texto ) );
     if ( '' !== $secundario ) {
         $mensaje .= '|' . trim( wp_strip_all_tags( $secundario ) );
+    }
+
+    $mostrar = get_option( $clave . '_mostrar', '1' );
+    if ( '0' === $mostrar ) {
+        return '';
     }
 
     return $mensaje;

--- a/languages/cdb-form.pot
+++ b/languages/cdb-form.pot
@@ -881,3 +881,11 @@ msgstr ""
 #: test.php:5
 msgid "Debes iniciar sesión."
 msgstr ""
+
+#: admin/config-mensajes.php:275
+msgid "Oculto"
+msgstr ""
+
+#: admin/config-mensajes.php:295
+msgid "Mostrar aviso"
+msgstr ""

--- a/languages/es_ES.po
+++ b/languages/es_ES.po
@@ -881,3 +881,11 @@ msgstr ""
 #: test.php:5
 msgid "Debes iniciar sesión."
 msgstr ""
+
+#: admin/config-mensajes.php:275
+msgid "Oculto"
+msgstr "Oculto"
+
+#: admin/config-mensajes.php:295
+msgid "Mostrar aviso"
+msgstr "Mostrar aviso"


### PR DESCRIPTION
## Resumen
- Añade casilla "Mostrar aviso" y etiqueta "Oculto" para controlar la visibilidad de cada mensaje en la configuración.
- Resalta avisos ocultos en la interfaz y permite alternarlos dinámicamente mediante JavaScript.
- Respeta la configuración de visibilidad al generar mensajes tanto en PHP como para scripts.

## Pruebas
- `php -l admin/config-mensajes.php`
- `php -l includes/messages.php`
- `node --check assets/js/config-mensajes.js`


------
https://chatgpt.com/codex/tasks/task_e_688f95958504832789615fb6bf178e5a