### PR TITLE
Use centralized message retrieval for experience shortcode

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -354,11 +354,7 @@ function cdb_experiencia_shortcode() {
     // La plantilla incluida volverá a validar este dato, generando comprobación redundante.
     $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
     if ($empleado_id === 0) {
-        return cdb_form_render_mensaje(
-            'cdb_mensaje_experiencia_sin_perfil',
-            'cdb_color_experiencia_sin_perfil',
-            __( 'No tienes un perfil de empleado registrado.', 'cdb-form' )
-        );
+        return cdb_form_get_mensaje('cdb_experiencia_sin_perfil');
     }
 
     // 4) Si pasa las verificaciones, se carga la plantilla del formulario.

--- a/templates/form-experiencia-template.php
+++ b/templates/form-experiencia-template.php
@@ -4,27 +4,6 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// Verificar si el usuario está conectado.
-$current_user = wp_get_current_user();
-if (!$current_user->exists()) {
-    echo cdb_form_render_mensaje(
-        'cdb_mensaje_login_requerido',
-        'cdb_color_login_requerido',
-        __( 'Debes iniciar sesión para gestionar tu empleado.', 'cdb-form' )
-    );
-    return;
-}
-
-// Obtener la ID del empleado asociado al usuario actual mediante la función específica.
-$empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
-if (!$empleado_id) {
-    echo cdb_form_get_mensaje(
-        'cdb_experiencia_sin_perfil'
-    );
-    echo do_shortcode('[cdb_form_empleado]');
-    return;
-}
-
 // (Opcional) Variables para inicializar campos en el formulario
 $bar_id_actual   = '';
 $anio_actual     = '';


### PR DESCRIPTION
## Summary
- Use `cdb_form_get_mensaje` in `[cdb_experiencia]` to display the “sin perfil” warning
- Drop redundant session and profile checks from experience template

## Testing
- `php -l includes/shortcodes.php`
- `php -l templates/form-experiencia-template.php`
- `php -r 'define("ABSPATH", __DIR__ . "/"); function get_option($k,$d=null){global $o; return $o[$k]??$d;} function update_option($k,$v){global $o;$o[$k]=$v;} function __($t,$d=null){return $t;} function esc_attr($s){return $s;} function wp_kses_post($s){return $s;} require "includes/messages.php"; update_option("cdb_experiencia_sin_perfil","Aviso modificado|Nueva nota"); echo cdb_form_get_mensaje("cdb_experiencia_sin_perfil")."\n";'

------
https://chatgpt.com/codex/tasks/task_e_688fae4e499883278316268135c04182