### PR TITLE
Cast mostrar before comparison

### DIFF
--- a/includes/messages.php
+++ b/includes/messages.php
@@ -245,7 +245,7 @@ function cdb_form_get_mensaje( $clave, $tipo = 'aviso' ) {
         $secundario = $parts[1] ?? '';
     }
 
-    if ( '0' === $mostrar ) {
+    if ( '0' == $mostrar ) {
         return '';
     }
 
@@ -312,7 +312,7 @@ function cdb_form_get_mensaje_js( $clave ) {
     }
 
     $mostrar = get_option( $clave . '_mostrar', '1' );
-    if ( '0' === $mostrar ) {
+    if ( '0' == $mostrar ) {
         return '';
     }
 


### PR DESCRIPTION
## Summary
- compare $mostrar using loose equality to avoid strict type mismatch, preventing message display issues

## Testing
- `php -l includes/messages.php`


------
https://chatgpt.com/codex/tasks/task_e_688fb7acc8908327833e0b96ed3f759e