### PR TITLE
refactor: init message config only when translations available

### DIFF
--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -1,10 +1,4 @@
 jQuery(document).ready(function($){
-
-    if (typeof cdbMensajes !== 'object') return;
-
-    var nuevoNombre = cdbMensajes.nuevoNombre || '';
-    var nuevaClase = cdbMensajes.nuevaClase || '';
-    var eliminar = cdbMensajes.eliminar || '';
     // Toggle edición de mensaje
     $('.cdb-edit-mensaje').on('click', function(){
         var cont = $(this).closest('.cdb-config-mensaje');
@@ -40,20 +34,26 @@ jQuery(document).ready(function($){
     }).trigger('change');
 
     // Añadir nuevo tipo/color
-    $('#cdb-add-tipo-color').on('click', function(e){
-        e.preventDefault();
-        var idx = $('#cdb-tipos-color .cdb-tipo-color-row').length + 1;
-        var row = $('<div class="cdb-tipo-color-row"></div>');
-        row.append('<input type="text" name="tipos_color[new_'+idx+'][name]" placeholder="'+nuevoNombre+'" />');
-        row.append('<input type="text" name="tipos_color[new_'+idx+'][class]" placeholder="'+nuevaClase+'" />');
-        row.append('<input type="color" name="tipos_color[new_'+idx+'][color]" value="#000000" />');
-        row.append('<input type="color" name="tipos_color[new_'+idx+'][text]" value="#ffffff" />');
-        row.append('<label><input type="checkbox" name="tipos_color[new_'+idx+'][delete]" value="1" /> '+eliminar+'</label>');
-        $('#cdb-tipos-color').append(row);
-    });
+    if (typeof cdbMensajes === 'object') {
+        var nuevoNombre = cdbMensajes.nuevoNombre || '';
+        var nuevaClase = cdbMensajes.nuevaClase || '';
+        var eliminar = cdbMensajes.eliminar || '';
+
+        $('#cdb-add-tipo-color').on('click', function(e){
+            e.preventDefault();
+            var idx = $('#cdb-tipos-color .cdb-tipo-color-row').length + 1;
+            var row = $('<div class="cdb-tipo-color-row"></div>');
+            row.append('<input type="text" name="tipos_color[new_'+idx+'][name]" placeholder="'+nuevoNombre+'" />');
+            row.append('<input type="text" name="tipos_color[new_'+idx+'][class]" placeholder="'+nuevaClase+'" />');
+            row.append('<input type="color" name="tipos_color[new_'+idx+'][color]" value="#000000" />');
+            row.append('<input type="color" name="tipos_color[new_'+idx+'][text]" value="#ffffff" />');
+            row.append('<label><input type="checkbox" name="tipos_color[new_'+idx+'][delete]" value="1" /> '+eliminar+'</label>');
+            $('#cdb-tipos-color').append(row);
+        });
+    }
 
     // Marcar fila como eliminada
-        $('#cdb-tipos-color').on('change', 'input[type="checkbox"]', function(){
+    $('#cdb-tipos-color').on('change', 'input[type="checkbox"]', function(){
         $(this).closest('.cdb-tipo-color-row').toggleClass('deleting', this.checked);
     });
 


### PR DESCRIPTION
## Summary
- Avoid aborting message config when `cdbMensajes` is absent
- Only initialize type/color addition when translations are defined

## Testing
- `npm test` (fails: Could not read package.json)
- `phpunit` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6891486a15d88327bdc61cc1dbb2ce0b