### PR TITLE
Use strict comparisons for message visibility checks

### DIFF
--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -277,7 +277,7 @@ function cdb_form_config_mensajes_page() {
                 $color_hex  = $datos_tipo['color'] ?? '#000';
                 $text_hex   = $datos_tipo['text'] ?? cdb_form_get_contrasting_text_color( $color_hex );
                 ?>
-                <div class="cdb-config-mensaje<?php echo ( '1' != $mostrar ) ? ' oculto' : ''; ?>" id="mensaje-<?php echo esc_attr( $id ); ?>">
+                <div class="cdb-config-mensaje<?php echo ( '1' !== $mostrar ) ? ' oculto' : ''; ?>" id="mensaje-<?php echo esc_attr( $id ); ?>">
                     <strong><?php echo esc_html( $datos['label'] ); ?></strong> <span class="cdb-oculto-label"><?php esc_html_e( 'Oculto', 'cdb-form' ); ?></span>
                     <div class="cdb-mensaje-preview <?php echo esc_attr( $clase ); ?>" style="border-left-color: <?php echo esc_attr( $color_hex ); ?>; background-color: <?php echo esc_attr( $color_hex ); ?>; color: <?php echo esc_attr( $text_hex ); ?>;">
                         <strong class="cdb-mensaje-destacado"><?php echo wp_kses_post( $texto ); ?></strong>

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -245,7 +245,7 @@ function cdb_form_get_mensaje( $clave, $tipo = 'aviso' ) {
         $secundario = $parts[1] ?? '';
     }
 
-    if ( '0' == $mostrar ) {
+    if ( '0' === $mostrar ) {
         return '';
     }
 
@@ -312,7 +312,7 @@ function cdb_form_get_mensaje_js( $clave ) {
     }
 
     $mostrar = get_option( $clave . '_mostrar', '1' );
-    if ( '0' == $mostrar ) {
+    if ( '0' === $mostrar ) {
         return '';
     }
 


### PR DESCRIPTION
## Summary
- Use strict comparison for `$mostrar` in config panel to handle hidden messages accurately
- Apply strict checks in message retrieval to respect disabled messages

## Testing
- `php -l admin/config-mensajes.php`
- `php -l includes/messages.php`


------
https://chatgpt.com/codex/tasks/task_e_68914e6eaf3883279d9154d87da0a279