### PR TITLE
Honor message visibility option

### DIFF
--- a/includes/messages.php
+++ b/includes/messages.php
@@ -378,6 +378,20 @@ function cdb_form_render_mensaje( $text_option, $color_option, $default_text, $d
         ),
         ''
     );
+    $mostrar    = cdb_form_get_option_compat(
+        array(
+            $text_option . '_mostrar',
+            $text_option . '_visible',
+            $text_option . '_mostrar_mensaje',
+            $text_option . '_mostrar_aviso',
+            $text_option . '_show',
+            $text_option . '_display',
+        ),
+        '1'
+    );
+    if ( '0' === $mostrar ) {
+        return '';
+    }
     $tipo       = get_option( $color_option, $default_tipo );
     $clase      = cdb_form_get_tipo_color_class( $tipo );
 


### PR DESCRIPTION
## Summary
- Respect message visibility settings in `cdb_form_render_mensaje` by reading `<text_option>_mostrar` and skipping output when disabled.
- Confirm templates and shortcodes now honor message visibility.

## Testing
- `php -l includes/messages.php`
- `php -l templates/form-empleado-template.php`
- `php -l templates/form-experiencia-template.php`
- `php -l includes/shortcodes.php`

------
https://chatgpt.com/codex/tasks/task_e_689160aa17048327862e106d7f9646fa