### PR TITLE
chore: normaliza claves de avisos configurables

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ También puedes registrar variantes desde código utilizando `cdb_form_register_
 <!-- ACTUALIZAR ESTA TABLA SI SE AÑADEN NUEVAS CLAVES EN $cdb_form_defaults -->
 | Clave | Texto por defecto | Contexto (dónde aparece) |
 | --- | --- | --- |
-| cdb_acceso_sin_login | **Debes iniciar sesión para acceder.** \| Inicia sesión o regístrate para continuar. | Formularios de bar o empleado cuando el usuario no ha iniciado sesión |
-| cdb_acceso_sin_permisos | **No tienes permisos para ver este contenido.** \| Contacta con un admin si crees que es un error. | Formulario de empleado cuando el usuario no tiene permisos |
-| cdb_aviso_sin_puntuacion | **Puntuación gráfica no disponible.** \| Añade más valoraciones para generar tu gráfico. | Panel de empleado cuando no hay gráfico |
-| cdb_bares_sin_resultados | **No hay bares que coincidan con tu búsqueda.** \| Ajusta filtros o prueba con otro término. | Búsqueda de bares sin resultados |
-| cdb_empleado_no_encontrado | **Empleado no encontrado.** \| Crea primero tu perfil de empleado para continuar. | Formulario de empleado cuando no existe perfil asociado |
-| cdb_empleados_sin_resultados | **Sin coincidencias para tu búsqueda.** \| Modifica los criterios e inténtalo de nuevo. | Búsqueda de empleados sin resultados |
-| cdb_empleados_vacio | **Aún no hay empleados registrados.** \| ¡Sé el primero en unirte al proyecto! | Rankings de empleados cuando no existen registros |
-| cdb_experiencia_sin_perfil | **Para registrar experiencia debes crear tu perfil.** \| Completa tu información de empleado y vuelve aquí. | Formulario de experiencia sin perfil de empleado |
+| cdb_mensaje_login_requerido | **Debes iniciar sesión para acceder.** \| Inicia sesión o regístrate para continuar. | Formularios de bar o empleado cuando el usuario no ha iniciado sesión |
+| cdb_mensaje_sin_permiso | **No tienes permisos para ver este contenido.** \| Contacta con un admin si crees que es un error. | Formulario de empleado cuando el usuario no tiene permisos |
+| cdb_mensaje_puntuacion_no_disponible | **Puntuación gráfica no disponible.** \| Añade más valoraciones para generar tu gráfico. | Panel de empleado cuando no hay gráfico |
+| cdb_mensaje_busqueda_sin_bares | **No hay bares que coincidan con tu búsqueda.** \| Ajusta filtros o prueba con otro término. | Búsqueda de bares sin resultados |
+| cdb_mensaje_empleado_no_encontrado | **Empleado no encontrado.** \| Crea primero tu perfil de empleado para continuar. | Formulario de empleado cuando no existe perfil asociado |
+| cdb_mensaje_busqueda_sin_empleados | **Sin coincidencias para tu búsqueda.** \| Modifica los criterios e inténtalo de nuevo. | Búsqueda de empleados sin resultados |
+| cdb_mensaje_sin_empleados | **Aún no hay empleados registrados.** \| ¡Sé el primero en unirte al proyecto! | Rankings de empleados cuando no existen registros |
+| cdb_mensaje_experiencia_sin_perfil | **Para registrar experiencia debes crear tu perfil.** \| Completa tu información de empleado y vuelve aquí. | Formulario de experiencia sin perfil de empleado |
 | cdb_ajax_exito_empleado | **Empleado creado correctamente.** \| El perfil se ha guardado sin problemas. | Respuesta exitosa al crear empleado por AJAX |
 | cdb_ajax_error_empleado | **Error al crear empleado.** \| Inténtalo de nuevo más tarde. | Fallo al crear empleado por AJAX |
 | cdb_ajax_exito_experiencia | **Experiencia registrada.** \| Se ha guardado la experiencia. | Registro de experiencia por AJAX |

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -216,7 +216,7 @@ function cdb_bienvenida_empleado_shortcode() {
             $output .= cdb_generar_barra_progreso_simple($puntuacion_total_final);
         } else {
             $output .= cdb_form_get_mensaje(
-                'cdb_aviso_sin_puntuacion'
+                'cdb_mensaje_puntuacion_no_disponible'
             );
         }
 
@@ -354,7 +354,7 @@ function cdb_experiencia_shortcode() {
     // La plantilla incluida volverá a validar este dato, generando comprobación redundante.
     $empleado_id = (int) cdb_obtener_empleado_id($current_user->ID);
     if ($empleado_id === 0) {
-        return cdb_form_get_mensaje('cdb_experiencia_sin_perfil');
+        return cdb_form_get_mensaje('cdb_mensaje_experiencia_sin_perfil');
     }
 
     // 4) Si pasa las verificaciones, se carga la plantilla del formulario.
@@ -432,7 +432,7 @@ function cdb_mostrar_puntuacion_total() {
     $puntuacion_total = get_post_meta($empleado_id, 'cdb_puntuacion_total', true);
     if (!$puntuacion_total) {
         return cdb_form_get_mensaje(
-            'cdb_aviso_sin_puntuacion',
+            'cdb_mensaje_puntuacion_no_disponible',
             'info'
         );
     }
@@ -484,7 +484,7 @@ function cdb_top_empleados_experiencia_precalculada_shortcode() {
     // 5) Si no hay empleados, avisar
     if (!$query->have_posts()) {
         return cdb_form_get_mensaje(
-            'cdb_empleados_vacio'
+            'cdb_mensaje_sin_empleados'
         );
     }
 
@@ -586,7 +586,7 @@ function cdb_top_empleados_puntuacion_total_shortcode() {
     // 5) Si no hay empleados, salimos.
     if (!$query->have_posts()) {
         return cdb_form_get_mensaje(
-            'cdb_empleados_vacio'
+            'cdb_mensaje_sin_empleados'
         );
     }
 

--- a/templates/busqueda-bares-table.php
+++ b/templates/busqueda-bares-table.php
@@ -1,6 +1,6 @@
 <?php if ( empty( $bares ) ) : ?>
     <?php echo cdb_form_get_mensaje(
-        'cdb_bares_sin_resultados'
+        'cdb_mensaje_busqueda_sin_bares'
     ); ?>
 <?php else : ?>
 <table class="cdb-busqueda-table">

--- a/templates/busqueda-empleados-table.php
+++ b/templates/busqueda-empleados-table.php
@@ -1,6 +1,6 @@
 <?php if ( empty( $empleados ) ) : ?>
     <?php echo cdb_form_get_mensaje(
-        'cdb_empleados_sin_resultados'
+        'cdb_mensaje_busqueda_sin_empleados'
     ); ?>
 <?php else : ?>
 <table class="cdb-busqueda-table">

--- a/templates/form-empleado-template.php
+++ b/templates/form-empleado-template.php
@@ -30,7 +30,7 @@ if (!empty($existing_empleado)) {
     $button_text         = __( 'Actualizar Empleado', 'cdb-form' );
 } else {
     echo cdb_form_get_mensaje(
-        'cdb_empleado_no_encontrado'
+        'cdb_mensaje_empleado_no_encontrado'
     );
     $empleado_id         = 0;
     $empleado_nombre     = '';


### PR DESCRIPTION
## Summary
- reemplaza claves obsoletas de avisos por las opciones `cdb_mensaje_*`
- actualiza la documentación de mensajes por defecto

## Testing
- `php -l includes/shortcodes.php`
- `php -l templates/form-empleado-template.php`
- `php -l templates/busqueda-bares-table.php`
- `php -l templates/busqueda-empleados-table.php`


------
https://chatgpt.com/codex/tasks/task_e_68916360497c83279495b3fa50261c7c