### PR TITLE
feat: add configurable borders for notices

### DIFF
--- a/admin/enqueue.php
+++ b/admin/enqueue.php
@@ -22,10 +22,11 @@ function cdb_form_admin_enqueue( $hook ) {
             array(),
             '1.0'
         );
+        wp_enqueue_style( 'wp-color-picker' );
         wp_enqueue_script(
             'cdb-form-config-mensajes',
             CDB_FORM_URL . 'assets/js/config-mensajes.js',
-            array( 'jquery' ),
+            array( 'jquery', 'wp-color-picker' ),
             '1.0',
             true
         );
@@ -33,9 +34,10 @@ function cdb_form_admin_enqueue( $hook ) {
             'cdb-form-config-mensajes',
             'cdbMensajes',
             array(
-                'nuevoNombre' => __( 'Nombre', 'cdb-form' ),
-                'nuevaClase'  => __( 'Clase CSS', 'cdb-form' ),
-                'eliminar'    => __( 'Eliminar', 'cdb-form' ),
+                'nuevoNombre'   => __( 'Nombre', 'cdb-form' ),
+                'nuevaClase'    => __( 'Clase CSS', 'cdb-form' ),
+                'eliminar'      => __( 'Eliminar', 'cdb-form' ),
+                'contrasteBajo' => __( 'Contraste bajo', 'cdb-form' ),
             )
         );
     }

--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -3,26 +3,20 @@
  *
  * Esta hoja se carga tanto en el administrador como en el frontend. Proporciona
  * la estructura principal de los mensajes (<div class="cdb-aviso">) mientras que
- * los colores específicos de cada tipo (fondo y texto) se añaden dinámicamente
- * desde public/enqueue.php mediante <code>wp_add_inline_style</code>.
+ * los colores y bordes específicos de cada tipo se añaden dinámicamente desde
+ * PHP mediante wp_add_inline_style.
  */
 .cdb-aviso {
-    padding: 8px 12px;
-    margin-bottom: 8px;
-    border-left: 4px solid transparent;
+    padding: 10px 15px;
+    margin: 15px 0;
 }
-
-.cdb-mensaje-destacado,
-.cdb-mensaje-secundario {
-    display: block;
-}
-
 .cdb-mensaje-destacado {
     font-weight: 700;
+    display: block;
 }
-
 .cdb-mensaje-secundario {
-    margin-top: 0;
+    display: block;
+    font-size: .9em;
 }
 
 /* Estilos utilizados únicamente en la pantalla de Configuración de Mensajes */
@@ -31,9 +25,10 @@
 .cdb-config-mensaje.oculto .cdb-mensaje-preview { opacity:0.5; }
 .cdb-oculto-label { display:none; margin-left:8px; font-style:italic; }
 .cdb-config-mensaje.oculto .cdb-oculto-label { display:inline; }
-.cdb-mensaje-preview { padding: 8px 12px; margin-bottom: 8px; border-left: 4px solid transparent; }
+.cdb-mensaje-preview { padding:10px 15px; margin:15px 0; }
 .cdb-color-swatch { display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:4px; vertical-align:middle; }
-.cdb-tipo-color-row { display:flex; align-items:center; gap:6px; margin-bottom:6px; }
+.cdb-tipo-color-row { display:flex; align-items:center; gap:6px; margin-bottom:6px; flex-wrap:wrap; }
 .cdb-tipo-color-row input[type="text"] { width:120px; }
 .cdb-tipo-color-row .cdb-color-swatch { width:20px; height:20px; }
 .cdb-tipo-color-row.deleting { opacity:0.5; }
+.cdb-contrast-warning { display:none; color:#d63638; font-size:11px; margin-left:4px; }

--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -2,9 +2,10 @@ jQuery(document).ready(function($){
 
     if (typeof cdbMensajes !== 'object') return;
 
-    var nuevoNombre = cdbMensajes.nuevoNombre || '';
-    var nuevaClase = cdbMensajes.nuevaClase || '';
-    var eliminar = cdbMensajes.eliminar || '';
+    var nuevoNombre   = cdbMensajes.nuevoNombre || '';
+    var nuevaClase    = cdbMensajes.nuevaClase || '';
+    var eliminar      = cdbMensajes.eliminar || '';
+    var contrasteBajo = cdbMensajes.contrasteBajo || '';
     // Toggle edición de mensaje
     $('.cdb-edit-mensaje').on('click', function(){
         var cont = $(this).closest('.cdb-config-mensaje');
@@ -25,17 +26,26 @@ jQuery(document).ready(function($){
     // Actualizar preview de colores y clase
     $('.cdb-mensaje-edicion select').on('change', function(){
         var opt   = $(this).find('option:selected');
-        var color = opt.data('color');
+        var bg    = opt.data('bg');
         var texto = opt.data('text');
         var cls   = opt.data('class');
+        var bcol  = opt.data('bordercolor');
+        var bwid  = opt.data('borderwidth');
+        var brad  = opt.data('borderradius');
         var cont  = $(this).closest('.cdb-config-mensaje');
         var prev  = cont.find('.cdb-mensaje-preview');
-        prev.removeClass().addClass('cdb-mensaje-preview').addClass(cls);
+        prev.removeClass().addClass('cdb-aviso cdb-mensaje-preview').addClass(cls);
         prev.css({
-            'border-left-color': color,
-            'background-color': color,
-            'color': texto
+            'background-color': bg,
+            'color': texto,
+            'border': bwid+' solid '+bcol,
+            'border-radius': brad
         });
+        if (parseFloat(bwid) === 0) {
+            prev.css('border-left', '4px solid '+bcol);
+        } else {
+            prev.css('border-left', '');
+        }
         cont.find('.cdb-clase-css').text(cls);
     }).trigger('change');
 
@@ -44,18 +54,57 @@ jQuery(document).ready(function($){
         e.preventDefault();
         var idx = $('#cdb-tipos-color .cdb-tipo-color-row').length + 1;
         var row = $('<div class="cdb-tipo-color-row"></div>');
+        row.append('<span class="cdb-color-swatch"></span>');
         row.append('<input type="text" name="tipos_color[new_'+idx+'][name]" placeholder="'+nuevoNombre+'" />');
         row.append('<input type="text" name="tipos_color[new_'+idx+'][class]" placeholder="'+nuevaClase+'" />');
-        row.append('<input type="color" name="tipos_color[new_'+idx+'][color]" value="#000000" />');
+        row.append('<input type="color" name="tipos_color[new_'+idx+'][bg]" value="#000000" />');
         row.append('<input type="color" name="tipos_color[new_'+idx+'][text]" value="#ffffff" />');
+        row.append('<input type="text" name="tipos_color[new_'+idx+'][border_color]" class="cdb-border-color" value="#000000" />');
+        row.append('<input type="text" name="tipos_color[new_'+idx+'][border_width]" list="cdb-border-width" value="0px" />');
+        row.append('<input type="text" name="tipos_color[new_'+idx+'][border_radius]" list="cdb-border-radius" value="4px" />');
         row.append('<label><input type="checkbox" name="tipos_color[new_'+idx+'][delete]" value="1" /> '+eliminar+'</label>');
+        row.append('<span class="cdb-contrast-warning">'+contrasteBajo+'</span>');
         $('#cdb-tipos-color').append(row);
+        row.find('.cdb-border-color').wpColorPicker();
     });
 
     // Marcar fila como eliminada
-        $('#cdb-tipos-color').on('change', 'input[type="checkbox"]', function(){
+    $('#cdb-tipos-color').on('change', 'input[type="checkbox"]', function(){
         $(this).closest('.cdb-tipo-color-row').toggleClass('deleting', this.checked);
     });
+
+    // Inicializar color picker en campos existentes
+    $('.cdb-border-color').wpColorPicker();
+
+    function hexToLuma(hex){
+        hex = hex.replace('#','');
+        if (hex.length === 3){ hex = hex.split('').map(function(h){ return h+h; }).join(''); }
+        var r = parseInt(hex.substr(0,2),16)/255;
+        var g = parseInt(hex.substr(2,2),16)/255;
+        var b = parseInt(hex.substr(4,2),16)/255;
+        var rs = r <= 0.03928 ? r/12.92 : Math.pow((r+0.055)/1.055,2.4);
+        var gs = g <= 0.03928 ? g/12.92 : Math.pow((g+0.055)/1.055,2.4);
+        var bs = b <= 0.03928 ? b/12.92 : Math.pow((b+0.055)/1.055,2.4);
+        return 0.2126*rs + 0.7152*gs + 0.0722*bs;
+    }
+    function contrastRatio(bg, txt){
+        var l1 = hexToLuma(bg)+0.05;
+        var l2 = hexToLuma(txt)+0.05;
+        return l1>l2 ? l1/l2 : l2/l1;
+    }
+    function updateContrast(row){
+        var bg = row.find('input[name$="[bg]"]').val();
+        var txt = row.find('input[name$="[text]"]').val();
+        row.find('.cdb-color-swatch').css('background-color', bg);
+        if (bg && txt){
+            var ratio = contrastRatio(bg, txt);
+            row.find('.cdb-contrast-warning').toggle(ratio < 4.5);
+        }
+    }
+    $('#cdb-tipos-color').on('input change', 'input[name$="[bg]"], input[name$="[text]"]', function(){
+        updateContrast($(this).closest('.cdb-tipo-color-row'));
+    });
+    $('#cdb-tipos-color .cdb-tipo-color-row').each(function(){ updateContrast($(this)); });
 
     // Controlar visibilidad de los avisos
     $('.cdb-mensaje-edicion input[data-role="mostrar"]').on('change', function(){

--- a/public/enqueue.php
+++ b/public/enqueue.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * color de fondo como el de texto, de modo que los shortcodes que imprimen
  * avisos pueden usar clases como <code>cdb-aviso--aviso</code> o cualquier
  * otra definida en la pantalla de ajustes y mantener los colores elegidos.
+ * Desde la versión 1.2 también se soporta borde completo configurable.
  */
 function cdb_form_public_enqueue() {
     // Registrar el script sin encolarlo; se encolará condicionalmente.
@@ -38,15 +39,23 @@ function cdb_form_public_enqueue() {
     $css   = '';
     foreach ( $tipos as $info ) {
         $class = isset( $info['class'] ) ? sanitize_html_class( $info['class'] ) : '';
-        $bg    = isset( $info['color'] ) ? sanitize_hex_color( $info['color'] ) : '';
+        $bg    = isset( $info['bg'] ) ? sanitize_hex_color( $info['bg'] ) : '';
         $text  = isset( $info['text'] ) ? sanitize_hex_color( $info['text'] ) : '';
+        $bcol  = isset( $info['border_color'] ) ? sanitize_hex_color( $info['border_color'] ) : $bg;
+        $bwid  = isset( $info['border_width'] ) ? cdb_form_normalize_border_value( $info['border_width'], '0px' ) : '0px';
+        $brad  = isset( $info['border_radius'] ) ? cdb_form_normalize_border_value( $info['border_radius'], '4px' ) : '4px';
         if ( ! $class || ! $bg ) {
             continue;
         }
         if ( ! $text ) {
             $text = cdb_form_get_contrasting_text_color( $bg );
         }
-        $css .= sprintf( '.%1$s{border-left-color:%2$s;background-color:%2$s;color:%3$s;}', $class, $bg, $text );
+        $rule = sprintf( '.cdb-aviso.%1$s{background-color:%2$s;color:%3$s;border:%4$s solid %5$s;border-radius:%6$s;}', $class, $bg, $text, $bwid, $bcol, $brad );
+        // Compatibilidad retro: si no hay borde, se mantiene el acento lateral histórico.
+        if ( preg_match( '/^0(?:px|rem|em|%)?$/', $bwid ) ) {
+            $rule = sprintf( '.cdb-aviso.%1$s{background-color:%2$s;color:%3$s;border-left:4px solid %5$s;border:%4$s solid %5$s;border-radius:%6$s;}', $class, $bg, $text, $bwid, $bcol, $brad );
+        }
+        $css .= $rule;
     }
 
     if ( $css ) {


### PR DESCRIPTION
## Summary
- add border color/width/radius settings for notice types
- generate full notice border styles and simplify base CSS
- enhance message configuration UI with live preview and contrast check

## Testing
- `php -l includes/messages.php`
- `php -l public/enqueue.php`
- `php -l admin/enqueue.php`
- `php -l admin/config-mensajes.php`
- `node --check assets/js/config-mensajes.js && echo "JS OK"`


------
https://chatgpt.com/codex/tasks/task_e_6895d855de40832797227a31b640bfd1