### PR TITLE
Add styled employee card shortcode with conditional CSS

### DIFF
--- a/assets/css/bienvenida-empleado.css
+++ b/assets/css/bienvenida-empleado.css
@@ -1,0 +1,26 @@
+.cdb-empleado-card {
+  display: inline-block;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background: #fff9f3;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  text-decoration: none;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+.cdb-empleado-card:hover,
+.cdb-empleado-card:focus-visible {
+  background: #f9f0e6;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+.cdb-empleado-card__label {
+  display: block;
+  font-size: 0.85rem;
+  color: #555;
+  margin-bottom: 0.25rem;
+}
+.cdb-empleado-card__name {
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: #a0522d;
+}

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -190,7 +190,10 @@ function cdb_bienvenida_empleado_shortcode() {
         $empleado_url     = get_permalink($empleado_id);
         $disponible       = get_post_meta($empleado_id, 'disponible', true);
 
-        $output .= '<p><strong>' . esc_html__( 'Tu empleado:', 'cdb-form' ) . '</strong> <a href="' . esc_url($empleado_url) . '">' . esc_html($empleado_nombre) . '</a></p>';
+        $output .= '<a class="cdb-empleado-card" href="' . esc_url( $empleado_url ) . '">'
+                 . '<span class="cdb-empleado-card__label">' . esc_html__( 'Tu empleado:', 'cdb-form' ) . '</span>'
+                 . '<span class="cdb-empleado-card__name">' . esc_html( $empleado_nombre ) . '</span>'
+                 . '</a>';
 
         // Formulario para actualizar disponibilidad.
         $output .= '<form id="cdb-update-disponibilidad" method="post">

--- a/public/enqueue.php
+++ b/public/enqueue.php
@@ -34,6 +34,22 @@ function cdb_form_public_enqueue() {
         '1.0'
     );
 
+    // Registrar la hoja de estilos de la tarjeta de empleado.
+    wp_register_style(
+        'cdb-form-bienvenida-empleado',
+        CDB_FORM_URL . 'assets/css/bienvenida-empleado.css',
+        array(),
+        '1.0'
+    );
+
+    // Encolar la hoja de estilos solo si el contenido incluye los shortcodes relevantes.
+    if ( is_singular() ) {
+        global $post;
+        if ( has_shortcode( $post->post_content, 'cdb_bienvenida_empleado' ) || has_shortcode( $post->post_content, 'cdb_bienvenida_usuario' ) ) {
+            wp_enqueue_style( 'cdb-form-bienvenida-empleado' );
+        }
+    }
+
     // Generar las reglas CSS para cada tipo/color definido.
     $tipos = cdb_form_get_tipos_color();
     $css   = '';


### PR DESCRIPTION
## Summary
- Transform [cdb_bienvenida_empleado] output into a clickable card linking to the employee profile.
- Add dedicated `bienvenida-empleado.css` for card styling and register/enqueue only when relevant shortcodes are present.

## Testing
- `php -l includes/shortcodes.php`
- `php -l public/enqueue.php`


------
https://chatgpt.com/codex/tasks/task_e_6895fae97f188327a6f41d597faff179