### PR TITLE
Refine employee card styles and meta info

### DIFF
--- a/assets/css/bienvenida-empleado.css
+++ b/assets/css/bienvenida-empleado.css
@@ -1,26 +1,50 @@
-.cdb-empleado-card {
-  display: inline-block;
-  padding: 1rem;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  background: #fff9f3;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-  text-decoration: none;
-  transition: background 0.2s ease, box-shadow 0.2s ease;
+:root{
+  --cdb-bg-page: #FAF8EE;        /* fondo página */
+  --cdb-beige:   #cdb888;        /* beige de los avisos */
+  --cdb-beige-2: #f7efe1;        /* beige suave para tarjeta */
+  --cdb-beige-3: #cdb888;        /* hover tarjeta */
+  --cdb-text:    #000;           /* texto principal */
+  --cdb-accent:  #000;           /* acento (nombre) */
+  --cdb-border:  #000;           /* borde sutil */
+  --cdb-shadow:  0 1px 3px rgba(0,0,0,.08);
+  --cdb-shadow-2:0 3px 10px rgba(0,0,0,.12);
+}
+.cdb-empleado-card{
+  display:flex; align-items:center; gap:.75rem;
+  padding:12px 16px;
+  border:1px solid var(--cdb-border);
+  border-radius:12px;
+  background:var(--cdb-beige-2);
+  box-shadow:var(--cdb-shadow);
+  text-decoration:none;
+  transition:background .2s ease, box-shadow .2s ease, transform .15s ease;
+  color:var(--cdb-text);
+  max-width:520px;
 }
 .cdb-empleado-card:hover,
-.cdb-empleado-card:focus-visible {
-  background: #f9f0e6;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+.cdb-empleado-card:focus-visible{
+  background:var(--cdb-beige-3);
+  box-shadow:var(--cdb-shadow-2);
+  transform:translateY(-1px);
+  outline:none;
 }
-.cdb-empleado-card__label {
-  display: block;
-  font-size: 0.85rem;
-  color: #555;
-  margin-bottom: 0.25rem;
+.cdb-empleado-card:focus-visible{ box-shadow:0 0 0 3px rgba(160,82,45,.25), var(--cdb-shadow-2); }
+.cdb-empleado-card__text{display:grid; line-height:1.15}
+.cdb-empleado-card__label{
+  font-size:.8rem; color:#6a6a6a; margin-bottom:2px;
+  text-transform:none; letter-spacing:.2px;
 }
-.cdb-empleado-card__name {
-  font-size: 1.1rem;
-  font-weight: bold;
-  color: #a0522d;
+.cdb-empleado-card__name{
+  font-size:1.15rem; font-weight:800; color:var(--cdb-accent);
+}
+.cdb-empleado-card__meta{
+  font-size:.78rem; color:#5a5a5a; margin-top:2px;
+}
+.cdb-empleado-card__chev{
+  margin-left:auto; font-size:1.1rem; opacity:.6; transition:transform .15s ease, opacity .2s ease;
+}
+.cdb-empleado-card:hover .cdb-empleado-card__chev{ transform:translateX(2px); opacity:.9; }
+@media (max-width:420px){
+  .cdb-empleado-card{ padding:10px 12px; border-radius:10px; }
+  .cdb-empleado-card__name{ font-size:1.05rem; }
 }


### PR DESCRIPTION
## Summary
- Revamp employee card styles and variables for improved visuals and hover/focus interactions
- Show total score and time since last evaluation in welcome card, including emoji and arrow icon

## Testing
- `php -l includes/shortcodes.php`
- `php -l public/enqueue.php`


------
https://chatgpt.com/codex/tasks/task_e_689607dee3a88327aa567a2b2a5ad6e8