### PR TITLE
Add helper to fetch latest valuation date

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,0 +1,29 @@
+<?php
+// Evitar acceso directo al archivo.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Obtiene la fecha de la última valoración registrada para un empleado.
+ *
+ * @param int $empleado_id ID del empleado.
+ * @return string|null Fecha de la última valoración en formato MySQL o null si no existe.
+ */
+function cdb_obtener_fecha_ultima_valoracion( $empleado_id ) {
+    global $wpdb;
+    $tabla_exp = $wpdb->prefix . 'cdb_experiencia';
+
+    $fecha = $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT MAX(fecha_modificacion) FROM {$tabla_exp} WHERE empleado_id = %d",
+            $empleado_id
+        )
+    );
+
+    if ( empty( $fecha ) ) {
+        return null;
+    }
+
+    return $fecha;
+}

--- a/includes/init.php
+++ b/includes/init.php
@@ -13,6 +13,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/cdb-bar/includes/cpt-equipo.php' ) ) {
 }
 
 // Incluir archivos esenciales del plugin
+require_once CDB_FORM_PATH . 'includes/helpers.php';
 require_once CDB_FORM_PATH . 'includes/form-handler.php';
 require_once CDB_FORM_PATH . 'includes/validations.php';
 require_once CDB_FORM_PATH . 'includes/capabilities.php';

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -199,12 +199,7 @@ function cdb_bienvenida_empleado_shortcode() {
             $puntuacion_total_final = floatval($puntuacion_total_meta) + ($puntuacion_experiencia / 100);
             $puntuacion_total_final = round($puntuacion_total_final, 1);
         }
-        $ultima_val = $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT MAX(fecha_modificacion) FROM {$tabla_exp} WHERE empleado_id = %d",
-                $empleado_id
-            )
-        );
+        $ultima_val = cdb_obtener_fecha_ultima_valoracion($empleado_id);
         if ($ultima_val) {
             $ultima_valoracion = human_time_diff(strtotime($ultima_val), current_time('timestamp'));
         } else {


### PR DESCRIPTION
## Summary
- add `cdb_obtener_fecha_ultima_valoracion` helper to centralize last valuation lookup
- include helper in plugin initialization
- use helper in employee welcome shortcode and format with `human_time_diff`

## Testing
- `php -l includes/helpers.php`
- `php -l includes/init.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68962c54e324832785d624ea36efd4f5