### PR TITLE
Improve employee card spacing and metric layout

### DIFF
--- a/assets/css/bienvenida-empleado.css
+++ b/assets/css/bienvenida-empleado.css
@@ -20,6 +20,7 @@
   transition:background .2s ease, box-shadow .2s ease, transform .15s ease;
   color:var(--cdb-text);
   max-width:520px;
+  margin-top:24px;
   margin-bottom:24px;
 }
 .cdb-empleado-card:hover,
@@ -48,7 +49,12 @@
   font-size:.85rem;
   color:#5a5a5a;
 }
-.cdb-empleado-card__meta-item{display:block; margin-top:2px; font-size:.84rem; color:#5a5a5a;}
+.cdb-empleado-card__meta-item{
+  display:block;
+  margin-top:4px;
+  font-size:.85rem;
+  color:#5a5a5a;
+}
 .cdb-empleado-disponibilidad{margin-bottom:24px;}
 .cdb-empleado-card__chev{
   margin-left:auto; font-size:1.1rem; opacity:.6; transition:transform .15s ease, opacity .2s ease;

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -226,22 +226,22 @@ function cdb_bienvenida_empleado_shortcode() {
 
         // Tarjeta con las métricas.
         $output .= '<a class="cdb-empleado-card" href="' . esc_url( $empleado_url ) . '">'
-                 . '<span class="cdb-empleado-card__text">'
+                 . '<div class="cdb-empleado-card__text">'
                  . '<span class="cdb-empleado-card__label">' . esc_html__( 'Tu empleado:', 'cdb-form' ) . '</span>'
                  . '<span class="cdb-empleado-card__name">👉 ' . esc_html( $empleado_nombre ) . '</span>'
-                 . '<span class="cdb-empleado-card__meta">'
-                 . '<span class="cdb-empleado-card__meta-item">' . esc_html__( 'Puntuación de Gráfica (empleados):', 'cdb-form' ) . ' ' . esc_html( $score_empleados ) . '</span>';
+                 . '<div class="cdb-empleado-card__meta">'
+                 . '<div class="cdb-empleado-card__meta-item">' . esc_html__( 'Puntuación de Gráfica (empleados):', 'cdb-form' ) . ' ' . esc_html( $score_empleados ) . '</div>';
         if ( null !== $score_empleadores ) {
-            $output .= '<span class="cdb-empleado-card__meta-item">' . esc_html__( 'Puntuación de Gráfica (empleadores):', 'cdb-form' ) . ' ' . esc_html( $score_empleadores ) . '</span>';
+            $output .= '<div class="cdb-empleado-card__meta-item">' . esc_html__( 'Puntuación de Gráfica (empleadores):', 'cdb-form' ) . ' ' . esc_html( $score_empleadores ) . '</div>';
         }
         if ( null !== $score_tutores ) {
-            $output .= '<span class="cdb-empleado-card__meta-item">' . esc_html__( 'Puntuación de Gráfica (tutores):', 'cdb-form' ) . ' ' . esc_html( $score_tutores ) . '</span>';
+            $output .= '<div class="cdb-empleado-card__meta-item">' . esc_html__( 'Puntuación de Gráfica (tutores):', 'cdb-form' ) . ' ' . esc_html( $score_tutores ) . '</div>';
         }
-        $output .= '<span class="cdb-empleado-card__meta-item">' . esc_html__( 'Puntuación de Experiencia:', 'cdb-form' ) . ' ' . esc_html( $puntuacion_experiencia ) . '</span>'
-                 . '<span class="cdb-empleado-card__meta-item">' . esc_html__( 'Puntuación Total:', 'cdb-form' ) . ' ' . esc_html( $puntuacion_total_final ) . '</span>'
-                 . '<span class="cdb-empleado-card__meta-item">' . sprintf( esc_html__( 'Última valoración hace %s', 'cdb-form' ), esc_html( $ultima_valoracion ) ) . '</span>'
-                 . '</span>'
-                 . '</span>'
+        $output .= '<div class="cdb-empleado-card__meta-item">' . esc_html__( 'Puntuación de Experiencia:', 'cdb-form' ) . ' ' . esc_html( $puntuacion_experiencia ) . '</div>'
+                 . '<div class="cdb-empleado-card__meta-item">' . esc_html__( 'Puntuación Total:', 'cdb-form' ) . ' ' . esc_html( $puntuacion_total_final ) . '</div>'
+                 . '<div class="cdb-empleado-card__meta-item">' . sprintf( esc_html__( 'Última valoración hace %s', 'cdb-form' ), esc_html( $ultima_valoracion ) ) . '</div>'
+                 . '</div>'
+                 . '</div>'
                  . '<span class="cdb-empleado-card__chev">&rsaquo;</span>'
                  . '</a>';
 


### PR DESCRIPTION
## Summary
- Add top margin to employee card for separation from availability block.
- Show score metrics vertically with dedicated div wrappers for readability.

## Testing
- `php -l includes/shortcodes.php`
- `php -l assets/css/bienvenida-empleado.css`


------
https://chatgpt.com/codex/tasks/task_e_689658589cf883279f06cdb4a15dd1b4