### PR TITLE
Fix employee card cache refresh and layout

### DIFF
--- a/assets/css/bienvenida-empleado.css
+++ b/assets/css/bienvenida-empleado.css
@@ -44,14 +44,15 @@
   margin-bottom:6px;
 }
 .cdb-empleado-card__meta{
-  display:block;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
   margin-top:0;
   font-size:.85rem;
   color:#5a5a5a;
 }
 .cdb-empleado-card__meta-item{
   display:block;
-  margin-top:4px;
   font-size:.85rem;
   color:#5a5a5a;
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -42,6 +42,15 @@ function cdb_obtener_fecha_ultima_valoracion( $empleado_id ) {
 function cdb_form_get_card_scores( $empleado_id, $bypass_cache = false ) {
     $cache_key = 'cdb_form_card_scores_' . $empleado_id;
 
+    // Permitir invalidaciones específicas para usuarios logueados que vuelven de una nueva valoración.
+    if ( ! $bypass_cache && is_user_logged_in() ) {
+        $user_id = get_current_user_id();
+        if ( get_user_meta( $user_id, 'cdb_form_card_cache_invalidated', true ) ) {
+            $bypass_cache = true;
+            delete_user_meta( $user_id, 'cdb_form_card_cache_invalidated' );
+        }
+    }
+
     if ( $bypass_cache ) {
         delete_transient( $cache_key );
     }
@@ -100,6 +109,15 @@ function cdb_form_get_grafica_scores_by_role( $empleado_id ) {
 function cdb_form_get_card_last_rating( $empleado_id, $bypass_cache = false ) {
     $cache_key = 'cdb_form_card_last_' . $empleado_id;
 
+    // Igual que en las puntuaciones, saltar la caché si se ha invalidado para el usuario actual.
+    if ( ! $bypass_cache && is_user_logged_in() ) {
+        $user_id = get_current_user_id();
+        if ( get_user_meta( $user_id, 'cdb_form_card_cache_invalidated', true ) ) {
+            $bypass_cache = true;
+            delete_user_meta( $user_id, 'cdb_form_card_cache_invalidated' );
+        }
+    }
+
     if ( $bypass_cache ) {
         delete_transient( $cache_key );
     }
@@ -132,4 +150,9 @@ function cdb_form_get_last_grafica_rating_datetime( $empleado_id ) {
 add_action( 'cdb_grafica_after_save', function( $empleado_id ) {
     delete_transient( 'cdb_form_card_scores_' . $empleado_id );
     delete_transient( 'cdb_form_card_last_' . $empleado_id );
+
+    // Marcar que la siguiente carga debe saltar la caché para el usuario actual.
+    if ( is_user_logged_in() ) {
+        update_user_meta( get_current_user_id(), 'cdb_form_card_cache_invalidated', 1 );
+    }
 } );

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -190,8 +190,11 @@ function cdb_bienvenida_empleado_shortcode() {
         $empleado_url     = get_permalink( $empleado_id );
         $disponible       = get_post_meta( $empleado_id, 'disponible', true );
 
-        // Saltar cachés cuando un usuario conectado visualiza la página de bienvenida.
-        $bypass_cache = is_user_logged_in() && is_page();
+        // Saltar cachés cuando un usuario conectado vuelve tras registrar una valoración.
+        $bypass_cache = false;
+        if ( is_user_logged_in() && is_page() ) {
+            $bypass_cache = (bool) get_user_meta( get_current_user_id(), 'cdb_form_card_cache_invalidated', true );
+        }
 
         // Puntuaciones de gráfica por rol.
         $scores            = cdb_form_get_card_scores( $empleado_id, $bypass_cache );


### PR DESCRIPTION
## Summary
- Force employee card metrics to bypass cache after new ratings
- Update employee welcome card markup and styles for clearer metric spacing

## Testing
- `php -l includes/helpers.php`
- `php -l includes/shortcodes.php`
- `php test.php`

------
https://chatgpt.com/codex/tasks/task_e_68966270e384832788aa2743b6c18c58