### PR TITLE
feat: expand employee card with detailed ratings

### DIFF
--- a/assets/css/bienvenida-empleado.css
+++ b/assets/css/bienvenida-empleado.css
@@ -43,11 +43,15 @@
   margin-bottom:6px;
 }
 .cdb-empleado-card__meta{
-  display:block;
+  display:flex;
+  flex-direction:column;
+  gap:2px;
   margin-top:0;
   font-size:.85rem;
   color:#5a5a5a;
 }
+.cdb-empleado-card__meta-line{display:block;}
+#cdb-update-disponibilidad{margin-bottom:24px;}
 .cdb-empleado-card__chev{
   margin-left:auto; font-size:1.1rem; opacity:.6; transition:transform .15s ease, opacity .2s ease;
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -7,23 +7,56 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Obtiene la fecha de la última valoración registrada para un empleado.
  *
+ * Si el plugin `cdb-grafica` está activo y provee la función
+ * `cdb_grafica_get_last_rating_datetime()`, se utiliza dicha función.
+ * En caso contrario, se consulta directamente la tabla
+ * `{prefix}grafica_empleado_results` de forma segura.
+ *
  * @param int $empleado_id ID del empleado.
  * @return string|null Fecha de la última valoración en formato MySQL o null si no existe.
  */
 function cdb_obtener_fecha_ultima_valoracion( $empleado_id ) {
+    if ( function_exists( 'cdb_grafica_get_last_rating_datetime' ) ) {
+        $fecha = cdb_grafica_get_last_rating_datetime( $empleado_id );
+        return $fecha ? $fecha : null;
+    }
+
     global $wpdb;
-    $tabla_exp = $wpdb->prefix . 'cdb_experiencia';
+    $tabla = $wpdb->prefix . 'grafica_empleado_results';
 
     $fecha = $wpdb->get_var(
         $wpdb->prepare(
-            "SELECT MAX(fecha_modificacion) FROM {$tabla_exp} WHERE empleado_id = %d",
+            "SELECT MAX(created_at) FROM {$tabla} WHERE empleado_id = %d",
             $empleado_id
         )
     );
 
-    if ( empty( $fecha ) ) {
-        return null;
+    return $fecha ? $fecha : null;
+}
+
+/**
+ * Obtiene la puntuación promedio de la gráfica para un rol específico.
+ *
+ * @param int    $empleado_id ID del empleado.
+ * @param string $rol         Rol del evaluador (empleado, empleador, tutor).
+ * @return float|null         Puntuación promedio o null si no hay registros.
+ */
+function cdb_obtener_puntuacion_grafica_por_rol( $empleado_id, $rol ) {
+    if ( function_exists( 'cdb_grafica_get_average_score_by_role' ) ) {
+        $score = cdb_grafica_get_average_score_by_role( $empleado_id, $rol );
+        return is_null( $score ) ? null : floatval( $score );
     }
 
-    return $fecha;
+    global $wpdb;
+    $tabla = $wpdb->prefix . 'grafica_empleado_results';
+
+    $score = $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT AVG(puntuacion_total) FROM {$tabla} WHERE empleado_id = %d AND rol = %s",
+            $empleado_id,
+            $rol
+        )
+    );
+
+    return is_null( $score ) ? null : round( floatval( $score ), 1 );
 }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -186,62 +186,100 @@ function cdb_bienvenida_empleado_shortcode() {
             );
         }
 
-        $empleado_nombre  = get_the_title($empleado_id);
-        $empleado_url     = get_permalink($empleado_id);
-        $disponible       = get_post_meta($empleado_id, 'disponible', true);
 
-        // Obtener la puntuación total y la fecha de la última valoración.
-        $puntuacion_total_meta = get_post_meta($empleado_id, 'cdb_puntuacion_total', true);
-        $puntuacion_experiencia = get_post_meta($empleado_id, 'cdb_experiencia_score', true);
-        $puntuacion_experiencia = intval($puntuacion_experiencia);
-        $puntuacion_total_final = 0;
-        if (!empty($puntuacion_total_meta)) {
-            $puntuacion_total_final = floatval($puntuacion_total_meta) + ($puntuacion_experiencia / 100);
-            $puntuacion_total_final = round($puntuacion_total_final, 1);
+        $empleado_nombre  = get_the_title( $empleado_id );
+        $empleado_url     = get_permalink( $empleado_id );
+        $disponible       = get_post_meta( $empleado_id, 'disponible', true );
+
+        // Obtener puntuaciones de gráfica por rol.
+        $puntuacion_grafica_empleados = cdb_obtener_puntuacion_grafica_por_rol( $empleado_id, 'empleado' );
+        if ( null === $puntuacion_grafica_empleados ) {
+            $meta_score = get_post_meta( $empleado_id, 'cdb_puntuacion_total', true );
+            if ( '' !== $meta_score ) {
+                $puntuacion_grafica_empleados = floatval( $meta_score );
+            }
         }
-        $ultima_val = cdb_obtener_fecha_ultima_valoracion($empleado_id);
-        if ($ultima_val) {
-            $ultima_valoracion = human_time_diff(strtotime($ultima_val), current_time('timestamp'));
+        $puntuacion_grafica_empleador = cdb_obtener_puntuacion_grafica_por_rol( $empleado_id, 'empleador' );
+        $puntuacion_grafica_tutor     = cdb_obtener_puntuacion_grafica_por_rol( $empleado_id, 'tutor' );
+
+        // Puntuación de experiencia y total final.
+        $puntuacion_experiencia = intval( get_post_meta( $empleado_id, 'cdb_experiencia_score', true ) );
+        $grafica_base = $puntuacion_grafica_empleados ? floatval( $puntuacion_grafica_empleados ) : 0;
+        $puntuacion_total_final = round( $grafica_base + ( $puntuacion_experiencia / 100 ), 1 );
+
+        // Última valoración en formato relativo.
+        $ultima_val = cdb_obtener_fecha_ultima_valoracion( $empleado_id );
+        if ( $ultima_val ) {
+            $ultima_valoracion = sprintf(
+                esc_html__( 'Última valoración: hace %s', 'cdb-form' ),
+                esc_html( human_time_diff( strtotime( $ultima_val ), current_time( 'timestamp' ) ) )
+            );
         } else {
-            $ultima_valoracion = __('sin registros', 'cdb-form');
+            $ultima_valoracion = esc_html__( 'Última valoración: sin registros', 'cdb-form' );
         }
 
+        // Formulario para actualizar disponibilidad (sobre la tarjeta).
+        $output .= '<form id="cdb-update-disponibilidad" class="cdb-disponibilidad-form" method="post">'
+                        . '<label for="disponible">' . esc_html__( 'Actualizar Disponibilidad:', 'cdb-form' ) . '</label>'
+                        . '<select id="disponible" name="disponible">'
+                            . '<option value="1" ' . selected( $disponible, 1, false ) . '>' . esc_html__( 'Sí', 'cdb-form' ) . '</option>'
+                            . '<option value="0" ' . selected( $disponible, 0, false ) . '>' . esc_html__( 'No', 'cdb-form' ) . '</option>'
+                        . '</select>'
+                        . '<input type="hidden" name="empleado_id" value="' . esc_attr( $empleado_id ) . '">'
+                        . '<input type="hidden" name="security" value="' . wp_create_nonce( 'cdb_form_nonce' ) . '">'
+                        . '<button type="submit">' . esc_html__( 'Actualizar', 'cdb-form' ) . '</button>'
+                    . '</form>';
+
+        // Preparar los metadatos de la tarjeta.
+        $meta_items = array();
+        if ( null !== $puntuacion_grafica_empleados ) {
+            $meta_items[] = sprintf(
+                esc_html__( 'Puntuación de Gráfica de Empleados: %s', 'cdb-form' ),
+                esc_html( $puntuacion_grafica_empleados )
+            );
+        }
+        if ( null !== $puntuacion_grafica_empleador ) {
+            $meta_items[] = sprintf(
+                esc_html__( 'Puntuación de Gráfica de Empleador: %s', 'cdb-form' ),
+                esc_html( $puntuacion_grafica_empleador )
+            );
+        }
+        if ( null !== $puntuacion_grafica_tutor ) {
+            $meta_items[] = sprintf(
+                esc_html__( 'Puntuación de Gráfica de Tutor: %s', 'cdb-form' ),
+                esc_html( $puntuacion_grafica_tutor )
+            );
+        }
+        $meta_items[] = sprintf(
+            esc_html__( 'Puntuación de Experiencia: %s', 'cdb-form' ),
+            esc_html( $puntuacion_experiencia )
+        );
+        $meta_items[] = sprintf(
+            esc_html__( 'Puntuación Total: %s', 'cdb-form' ),
+            esc_html( $puntuacion_total_final )
+        );
+        $meta_items[] = $ultima_valoracion;
+
+        // Tarjeta del empleado con metadatos.
         $output .= '<a class="cdb-empleado-card" href="' . esc_url( $empleado_url ) . '">'
                  . '<span class="cdb-empleado-card__text">'
                  . '<span class="cdb-empleado-card__label">' . esc_html__( 'Tu empleado:', 'cdb-form' ) . '</span>'
                  . '<span class="cdb-empleado-card__name">👉 ' . esc_html( $empleado_nombre ) . '</span>'
-                 . '<span class="cdb-empleado-card__meta">' . sprintf(
-                        esc_html__( 'Puntuación total %1$s · Última valoración hace %2$s', 'cdb-form' ),
-                        esc_html( $puntuacion_total_final ),
-                        esc_html( $ultima_valoracion )
-                    ) . '</span>'
+                 . '<span class="cdb-empleado-card__meta">';
+        foreach ( $meta_items as $item ) {
+            $output .= '<span class="cdb-empleado-card__meta-line">' . $item . '</span>';
+        }
+        $output .= '</span>'
                  . '</span>'
                  . '<span class="cdb-empleado-card__chev">&rsaquo;</span>'
                  . '</a>';
 
-        // Formulario para actualizar disponibilidad.
-        $output .= '<form id="cdb-update-disponibilidad" method="post">
-                        <label for="disponible">' . esc_html__( 'Actualizar Disponibilidad:', 'cdb-form' ) . '</label>
-                        <select id="disponible" name="disponible">
-                            <option value="1" ' . selected($disponible, 1, false) . '>' . esc_html__( 'Sí', 'cdb-form' ) . '</option>
-                            <option value="0" ' . selected($disponible, 0, false) . '>' . esc_html__( 'No', 'cdb-form' ) . '</option>
-                        </select>
-                        <input type="hidden" name="empleado_id" value="' . esc_attr($empleado_id) . '">
-                        <input type="hidden" name="security" value="' . wp_create_nonce('cdb_form_nonce') . '">
-                        <button type="submit">' . esc_html__( 'Actualizar', 'cdb-form' ) . '</button>
-                    </form>';
-
-        // Mostrar la barra de puntuación total si existe.
-        if (!empty($puntuacion_total_meta)) {
-            $output .= cdb_generar_barra_progreso_simple($puntuacion_total_final);
+        // Mostrar la barra de puntuación total si existen datos de gráfica.
+        if ( null !== $puntuacion_grafica_empleados ) {
+            $output .= cdb_generar_barra_progreso_simple( $puntuacion_total_final );
         } else {
-            $output .= cdb_form_get_mensaje(
-                'cdb_mensaje_puntuacion_no_disponible'
-            );
+            $output .= cdb_form_get_mensaje( 'cdb_mensaje_puntuacion_no_disponible' );
         }
-
-        // Mostrar la Puntuación de Experiencia.
-        $output .= '<p><strong>' . esc_html__( 'Puntuación de Experiencia:', 'cdb-form' ) . '</strong> ' . esc_html($puntuacion_experiencia) . '</p>';
     } else {
         // Mensaje para empleados que aún no han creado su perfil.
         // Configurable desde 'cdb_mensaje_bienvenida_usuario' y 'cdb_color_bienvenida_usuario'.
@@ -330,8 +368,6 @@ function cdb_generar_barra_progreso_simple($puntuacion_total) {
             <div class="cdb-progress-marker" style="left: 81%; color: #07ada8;">4</div>
         </div>
     </div>
-    <!-- Mostrar la puntuación total -->
-    <p><strong>Puntuación Total:</strong> <?php echo $puntuacion_total; ?>/100</p>
     <?php
     return ob_get_clean();
 }
@@ -422,7 +458,7 @@ add_shortcode('cdb_form_bar', 'cdb_form_bar_shortcode');
 /*---------------------------------------------------------------
  * 7. SHORTCODE [cdb_puntuacion_total]
  *---------------------------------------------------------------
- * Muestra la Puntuación Total (meta 'cdb_puntuacion_total') del empleado para la gráfica.
+ * Muestra la Puntuación de Gráfica (meta 'cdb_puntuacion_total') del empleado.
  *---------------------------------------------------------------*/
 
 /**
@@ -611,7 +647,7 @@ function cdb_top_empleados_puntuacion_total_shortcode() {
     }
 
     // 6) Cabecera de la tabla
-    $output  = '<h3>Top 21 Empleados por Puntuación Total (Gráfica)</h3>';
+    $output  = '<h3>Top 21 Empleados por Puntuación de Gráfica</h3>';
     $output .= '<table style="width:100%; border-collapse: collapse;">';
     $output .= '<thead>';
     $output .= '<tr>';
@@ -865,11 +901,11 @@ function cdb_top_bares_puntuacion_total_shortcode() {
         return cdb_form_render_mensaje(
             'cdb_mensaje_busqueda_sin_bares',
             'cdb_color_busqueda_sin_bares',
-            __( 'No se encontraron bares con puntuación total.', 'cdb-form' )
+            __( 'No se encontraron bares con puntuación de gráfica.', 'cdb-form' )
         );
     }
 
-    $output  = '<h3>Top 21 Bares por Puntuación Total (Gráfica)</h3>';
+    $output  = '<h3>Top 21 Bares por Puntuación de Gráfica</h3>';
     $output .= '<table style="width:100%; border-collapse: collapse;">';
     $output .= '<thead>';
     $output .= '<tr>';


### PR DESCRIPTION
## Summary
- expand employee welcome card with per-role graph, experience, total and last rating
- move availability update form above the card and remove redundant score lines
- style card meta for multi-line metrics

## Testing
- `php -l includes/helpers.php`
- `php -l includes/shortcodes.php`
- `php -l assets/css/bienvenida-empleado.css`


------
https://chatgpt.com/codex/tasks/task_e_689671dcbdd083279552db31fbb0c49c