### PR TITLE
feat: show graph scores and last rating on employee card

### DIFF
--- a/assets/css/bienvenida-empleado.css
+++ b/assets/css/bienvenida-empleado.css
@@ -20,7 +20,7 @@
   transition:background .2s ease, box-shadow .2s ease, transform .15s ease;
   color:var(--cdb-text);
   max-width:520px;
-  margin-bottom:24px;
+  margin-top:24px;
 }
 .cdb-empleado-card:hover,
 .cdb-empleado-card:focus-visible{
@@ -42,12 +42,8 @@
   display:block;
   margin-bottom:6px;
 }
-.cdb-empleado-card__meta{
-  display:block;
-  margin-top:0;
-  font-size:.85rem;
-  color:#5a5a5a;
-}
+.cdb-empleado-card__meta{ display:block; }
+.cdb-empleado-card__meta-item{ display:block; margin-top:2px; font-size:.85rem; color:#5a5a5a; }
 .cdb-empleado-card__chev{
   margin-left:auto; font-size:1.1rem; opacity:.6; transition:transform .15s ease, opacity .2s ease;
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -27,3 +27,33 @@ function cdb_obtener_fecha_ultima_valoracion( $empleado_id ) {
 
     return $fecha;
 }
+
+/**
+ * Wrapper for cdb_grafica_get_scores_by_role().
+ *
+ * @param int $empleado_id Employee ID.
+ * @return array Scores by role: ['empleado'=>?float,'empleador'=>?float,'tutor'=>?float]
+ */
+function cdb_form_get_graph_scores_by_role( int $empleado_id ): array {
+    $out = [ 'empleado' => null, 'empleador' => null, 'tutor' => null ];
+    if ( function_exists( 'cdb_grafica_get_scores_by_role' ) && $empleado_id > 0 ) {
+        $data = cdb_grafica_get_scores_by_role( $empleado_id, [] );
+        foreach ( [ 'empleado', 'empleador', 'tutor' ] as $k ) {
+            $out[ $k ] = isset( $data[ $k ] ) ? ( is_null( $data[ $k ] ) ? null : (float) $data[ $k ] ) : null;
+        }
+    }
+    return $out;
+}
+
+/**
+ * Wrapper for cdb_grafica_get_last_rating_datetime().
+ *
+ * @param int $empleado_id Employee ID.
+ * @return string|null Datetime string or null.
+ */
+function cdb_form_get_graph_last_datetime( int $empleado_id ): ?string {
+    if ( function_exists( 'cdb_grafica_get_last_rating_datetime' ) && $empleado_id > 0 ) {
+        return cdb_grafica_get_last_rating_datetime( $empleado_id );
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary
- use cdb-grafica API wrappers to fetch per-role scores and last rating
- move availability form above employee card and display detailed meta scores
- clean up redundant score lines and style card spacing

## Testing
- `php -l includes/helpers.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_689680912f6c832796217de7cc65e4a3