### PR TITLE
Improve employee welcome card spacing and metrics styling

### DIFF
--- a/assets/css/bienvenida-empleado.css
+++ b/assets/css/bienvenida-empleado.css
@@ -132,3 +132,35 @@
     margin-bottom: 20px;
   }
 }
+
+/* Espacio entre el <select> de disponibilidad y el botón */
+.cdb-disponibilidad-wrap select {
+  margin-right: 14px; /* antes 8px; da más respiro */
+}
+
+/* Más espacio entre la tarjeta y la barra de nivel */
+.cdb-empleado-card {
+  margin-bottom: 24px; /* antes ~16px; separa de la barra */
+}
+
+/* Si tienes wrapper de la barra, mantenemos separación inferior coherente */
+.cdb-barra-nivel-wrap {
+  margin-top: 8px;        /* desde la tarjeta */
+  margin-bottom: 28px;    /* hacia la tabla */
+}
+
+/* Negrita para números de métricas en la tarjeta */
+.cdb-empleado-card .cdb-num {
+  font-weight: 700;
+}
+
+/* “Puntuación Total” y su valor: negrita explícita */
+.cdb-empleado-card .cdb-meta--total,
+.cdb-empleado-card .cdb-meta--total .cdb-num {
+  font-weight: 800;
+}
+
+/* Opcional: un pelín más de interlínea para legibilidad en meta */
+.cdb-empleado-card__meta {
+  line-height: 1.45;
+}

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -230,32 +230,32 @@ function cdb_bienvenida_empleado_shortcode() {
 
         if ( cdb_form_card_show_role_score( 'empleado', $scores_roles['empleado'], (int) $empleado_id ) ) {
             $output .= '<div class="cdb-empleado-card__meta-item">' .
-                esc_html( $labels['empleado'] ?? __( 'Puntuación de Gráfica por Empleados:', 'cdb-form' ) ) . ' ' .
-                esc_html( number_format_i18n( $scores_roles['empleado'], $dec ) ) .
+                esc_html( $labels['empleado'] ?? __( 'Puntuación de Gráfica por Empleados:', 'cdb-form' ) ) . ' <span class="cdb-num">' .
+                esc_html( number_format_i18n( $scores_roles['empleado'], $dec ) ) . '</span>' .
             '</div>';
         }
 
         if ( ! is_null( $scores_roles['empleador'] ) && cdb_form_card_show_role_score( 'empleador', $scores_roles['empleador'], (int) $empleado_id ) ) {
             $output .= '<div class="cdb-empleado-card__meta-item">' .
-                esc_html( $labels['empleador'] ?? __( 'Puntuación de Gráfica por Empleadores:', 'cdb-form' ) ) . ' ' .
-                esc_html( number_format_i18n( $scores_roles['empleador'], $dec ) ) .
+                esc_html( $labels['empleador'] ?? __( 'Puntuación de Gráfica por Empleadores:', 'cdb-form' ) ) . ' <span class="cdb-num">' .
+                esc_html( number_format_i18n( $scores_roles['empleador'], $dec ) ) . '</span>' .
             '</div>';
         }
 
         if ( ! is_null( $scores_roles['tutor'] ) && cdb_form_card_show_role_score( 'tutor', $scores_roles['tutor'], (int) $empleado_id ) ) {
             $output .= '<div class="cdb-empleado-card__meta-item">' .
-                esc_html( $labels['tutor'] ?? __( 'Puntuación de Gráfica por Tutores:', 'cdb-form' ) ) . ' ' .
-                esc_html( number_format_i18n( $scores_roles['tutor'], $dec ) ) .
+                esc_html( $labels['tutor'] ?? __( 'Puntuación de Gráfica por Tutores:', 'cdb-form' ) ) . ' <span class="cdb-num">' .
+                esc_html( number_format_i18n( $scores_roles['tutor'], $dec ) ) . '</span>' .
             '</div>';
         }
 
         $output .= '<div class="cdb-empleado-card__meta-item">' .
-            esc_html( $labels['experiencia'] ?? __( 'Puntuación de Experiencia:', 'cdb-form' ) ) . ' ' .
-            esc_html( number_format_i18n( $puntuacion_experiencia, $dec ) ) .
+            esc_html( $labels['experiencia'] ?? __( 'Puntuación de Experiencia:', 'cdb-form' ) ) . ' <span class="cdb-num">' .
+            esc_html( number_format_i18n( $puntuacion_experiencia, $dec ) ) . '</span>' .
         '</div>' .
-        '<div class="cdb-empleado-card__meta-item">' .
-            esc_html( $labels['total'] ?? __( 'Puntuación Total:', 'cdb-form' ) ) . ' ' .
-            esc_html( number_format_i18n( $puntuacion_total_final, $dec ) ) .
+        '<div class="cdb-empleado-card__meta-item cdb-meta--total">' .
+            esc_html( $labels['total'] ?? __( 'Puntuación Total:', 'cdb-form' ) ) . ' <span class="cdb-num">' .
+            esc_html( number_format_i18n( $puntuacion_total_final, $dec ) ) . '</span>' .
         '</div>' .
         '<div class="cdb-empleado-card__meta-item">' .
             esc_html( $labels['ultima'] ?? __( 'Última valoración:', 'cdb-form' ) ) . ' ' .


### PR DESCRIPTION
## Summary
- Increase spacing around availability select and employee card
- Emphasize numerical scores in employee card and highlight total score

## Testing
- `php -l includes/shortcodes.php`
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689718fe407c8327bcafff7812b1371c