### PR TITLE
Improve employee card spacing and metrics

### DIFF
--- a/assets/css/bienvenida-empleado.css
+++ b/assets/css/bienvenida-empleado.css
@@ -43,7 +43,7 @@
   margin-bottom:6px;
 }
 .cdb-empleado-card__meta{ display:block; }
-.cdb-empleado-card__meta-item{ display:block; margin-top:2px; font-size:.85rem; line-height:1.25; color:#5a5a5a; }
+.cdb-empleado-card__meta-item{ display:block; font-size:.85rem; color:#5a5a5a; }
 .cdb-empleado-card__chev{
   margin-left:auto; font-size:1.1rem; opacity:.6; transition:transform .15s ease, opacity .2s ease;
 }
@@ -90,20 +90,14 @@
 }
 
 /* --- Bloque "Actualizar Disponibilidad" --- */
-/* Asegura un respiro inferior antes de la tarjeta */
-.cdb-disponibilidad-wrap{        /* si no existe la clase, crea un contenedor en CSS con el selector que envuelve el select + botón */
-  margin-bottom: 12px;
+.cdb-disponibilidad-wrap{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  margin-bottom:12px;
 }
-
-/* Ajuste suave del botón y select (no cambia su estilo general) */
-.cdb-disponibilidad-wrap select{
-  margin-right: 8px;
-}
-
-/* --- Barra de nivel --- */
-.cdb-barra-nivel-wrap{           /* si existe un wrapper; si no, aplicar al selector actual de la barra */
-  margin-top: 8px;               /* separa de la tarjeta */
-  margin-bottom: 24px;           /* separa de la sección siguiente */
+@media (max-width:480px){
+  .cdb-disponibilidad-wrap{ gap:10px; }
 }
 
 /* --- Inicio de tabla "Tu experiencia laboral" --- */
@@ -123,7 +117,7 @@
   .cdb-empleado-card{
     padding: 14px 14px;
     margin-top: 20px;
-    margin-bottom: 14px;
+    margin-bottom: 20px;
   }
   .cdb-empleado-card__meta{
     font-size: .9rem;
@@ -133,34 +127,37 @@
   }
 }
 
-/* Espacio entre el <select> de disponibilidad y el botón */
-.cdb-disponibilidad-wrap select {
-  margin-right: 14px; /* antes 8px; da más respiro */
-}
-
 /* Más espacio entre la tarjeta y la barra de nivel */
 .cdb-empleado-card {
-  margin-bottom: 24px; /* antes ~16px; separa de la barra */
+  margin-bottom: 28px; /* antes ~16–24px */
 }
 
 /* Si tienes wrapper de la barra, mantenemos separación inferior coherente */
-.cdb-barra-nivel-wrap {
-  margin-top: 8px;        /* desde la tarjeta */
+.cdb-barra-nivel-wrap,
+.cdb-barra-nivel--wrap {
+  margin-top: 20px;        /* desde la tarjeta */
   margin-bottom: 28px;    /* hacia la tabla */
 }
 
-/* Negrita para números de métricas en la tarjeta */
+/* Números en negrita (todas las métricas) */
 .cdb-empleado-card .cdb-num {
   font-weight: 700;
 }
 
-/* “Puntuación Total” y su valor: negrita explícita */
-.cdb-empleado-card .cdb-meta--total,
+/* “Puntuación Total” y su valor: un poco más de énfasis */
+.cdb-empleado-card .cdb-meta--total {
+  font-weight: 800;
+}
 .cdb-empleado-card .cdb-meta--total .cdb-num {
   font-weight: 800;
 }
 
-/* Opcional: un pelín más de interlínea para legibilidad en meta */
+/* Legibilidad de líneas de meta */
 .cdb-empleado-card__meta {
-  line-height: 1.45;
+  display:block;
+  line-height:1.45;
+}
+.cdb-empleado-card__meta-item {
+  display:block;
+  margin-top:3px;
 }


### PR DESCRIPTION
## Summary
- Wrap availability form controls for cleaner layout
- Reorder employee metrics and highlight total score
- Adjust spacing and typography for card and score bar

## Testing
- `php -l includes/shortcodes.php`
- `npx stylelint assets/css/bienvenida-empleado.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68971e988ee08327a166b199d5576d99