### PR TITLE
Shortened metric labels and tweaked update button

### DIFF
--- a/assets/css/bienvenida-empleado.css
+++ b/assets/css/bienvenida-empleado.css
@@ -161,3 +161,12 @@
   display:block;
   margin-top:3px;
 }
+
+@media (max-width: 480px) {
+  .cdb-bienvenida-actualizar-btn {
+    font-size: 0.9rem;
+    padding: 0.4em 0.8em;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -93,12 +93,12 @@ function cdb_form_card_number_decimals(): int {
  */
 function cdb_form_card_default_labels(): array {
     return [
-        'empleado'    => __( 'Puntuación de Gráfica por Empleados:', 'cdb-form' ),
-        'empleador'   => __( 'Puntuación de Gráfica por Empleadores:', 'cdb-form' ),
-        'tutor'       => __( 'Puntuación de Gráfica por Tutores:', 'cdb-form' ),
-        'experiencia' => __( 'Puntuación de Experiencia:', 'cdb-form' ),
-        'total'       => __( 'Puntuación Total:', 'cdb-form' ),
-        'ultima'      => __( 'Última valoración:', 'cdb-form' ),
+        'empleado'    => apply_filters( 'cdb_form_label_empleado', __( 'Punt. de Gráfica por Empleados:', 'cdb-form' ) ),
+        'empleador'   => apply_filters( 'cdb_form_label_empleador', __( 'Punt. de Gráfica por Empleadores:', 'cdb-form' ) ),
+        'tutor'       => apply_filters( 'cdb_form_label_tutor', __( 'Punt. de Gráfica por Tutores:', 'cdb-form' ) ),
+        'experiencia' => apply_filters( 'cdb_form_label_experiencia', __( 'Punt. de Experiencia:', 'cdb-form' ) ),
+        'total'       => apply_filters( 'cdb_form_label_total', __( 'Puntuación Total:', 'cdb-form' ) ),
+        'ultima'      => apply_filters( 'cdb_form_label_ultima', __( 'Última valoración:', 'cdb-form' ) ),
     ];
 }
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -217,7 +217,7 @@ function cdb_bienvenida_empleado_shortcode() {
                             .'<option value="1" ' . selected( $disponible, 1, false ) . '>' . esc_html__( 'Sí', 'cdb-form' ) . '</option>'
                             .'<option value="0" ' . selected( $disponible, 0, false ) . '>' . esc_html__( 'No', 'cdb-form' ) . '</option>'
                         .'</select>'
-                        .'<button type="submit">' . esc_html__( 'Actualizar', 'cdb-form' ) . '</button>'
+                        .'<button type="submit" class="cdb-bienvenida-actualizar-btn">' . esc_html__( 'Actualizar', 'cdb-form' ) . '</button>'
                     .'</div>'
                     .'<input type="hidden" name="empleado_id" value="' . esc_attr( $empleado_id ) . '">'
                     .'<input type="hidden" name="security" value="' . esc_attr( wp_create_nonce( 'cdb_form_nonce' ) ) . '">' 
@@ -286,7 +286,7 @@ function cdb_bienvenida_empleado_shortcode() {
 
             $output .= '<div class="cdb-empleado-card__meta-item' . $classes . '">' .
                         $label . ' ' .
-                        '<strong class="cdb-num">' . esc_html( $valor ) . '</strong>' .
+                        '<span class="cdb-num">' . esc_html( $valor ) . '</span>' .
                        '</div>';
         }
 


### PR DESCRIPTION
## Summary
- Shorten metric labels on the employee welcome card and wrap values in bold spans
- Add per-label filters for future customization
- Style update button for mobile and ensure single-line display

## Testing
- `php -l includes/helpers.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68972291038c832794a386d49d9ff869