### PR TITLE
Render role-based level bars for welcome shortcode

### DIFF
--- a/assets/css/cdb-bienvenida-niveles.css
+++ b/assets/css/cdb-bienvenida-niveles.css
@@ -1,0 +1,45 @@
+/* Contenedor general */
+.cdb-niveles--bienvenida { display: block; margin-top: 12px; }
+
+/* Cabecera */
+.cdb-niveles__head { display: grid; grid-template-columns: 120px 1fr; align-items: end; gap: 12px; margin-bottom: 8px; }
+.cdb-niveles__head-label { font-weight: 600; color: #222; }
+.cdb-niveles__scale { position: relative; height: 24px; }
+/* Reutiliza las marcas existentes de la barra original. Si no existen como clases sueltas, clónalas dentro de este contenedor. */
+.cdb-niveles__scale .cdb-progress-marker { position: absolute; transform: translateX(-50%); font-size: 12px; font-weight: bold; }
+
+/* Filas */
+.cdb-niveles__row { display: grid; grid-template-columns: 120px 1fr min-content; align-items: center; gap: 12px; margin: 6px 0; }
+.cdb-niveles__label { font-weight: 700; }
+.cdb-niveles__value { font-weight: 800; font-variant-numeric: tabular-nums; }
+
+/* Pista y relleno */
+.cdb-niveles__track { position: relative; height: 16px; border-radius: 999px; overflow: hidden; background: #eee; }
+.cdb-niveles__fill { height: 100%; transform-origin: left center; transform: scaleX(0); /* para animación */ transition: transform 0.9s ease-in-out; }
+.cdb-niveles__fill.is-in { transform: scaleX(1); }
+
+/* Colores base por rol (fondo de pista y color del relleno) */
+.cdb-niveles__row--empleados .cdb-niveles__track { background: #e0e0e0; }
+.cdb-niveles__row--empleados .cdb-niveles__fill  { background: var(--cdb-color-empleado-fill, #9aa0a6); }
+
+.cdb-niveles__row--empleadores .cdb-niveles__track { background: #555555; }
+.cdb-niveles__row--empleadores .cdb-niveles__fill  { background: var(--cdb-color-empleador-fill, #777777); }
+
+.cdb-niveles__row--tutores .cdb-niveles__track { background: #cdb888; }
+.cdb-niveles__row--tutores .cdb-niveles__fill  { background: var(--cdb-color-tutor-fill, #cdb888); }
+
+/* Estado sin valoraciones */
+.cdb-niveles__row[data-empty="1"] .cdb-niveles__fill { display: none; }
+.cdb-niveles__row[data-empty="1"] .cdb-niveles__track { opacity: .5; position: relative; }
+.cdb-niveles__row[data-empty="1"] .cdb-niveles__track::after {
+  content: "Sin valoraciones";
+  position: absolute; inset: 0; display: grid; place-items: center;
+  font-size: 12px; color: #333;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .cdb-niveles__head,
+  .cdb-niveles__row { grid-template-columns: 100px 1fr min-content; }
+  .cdb-niveles__track { height: 14px; }
+}

--- a/assets/js/cdb-bienvenida-niveles.js
+++ b/assets/js/cdb-bienvenida-niveles.js
@@ -1,0 +1,9 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    document.querySelectorAll('.cdb-niveles__fill').forEach(function(el){
+      // Forzar reflujo y activar animación
+      void el.offsetWidth;
+      el.classList.add('is-in');
+    });
+  });
+})();

--- a/public/enqueue.php
+++ b/public/enqueue.php
@@ -42,11 +42,28 @@ function cdb_form_public_enqueue() {
         '1.0'
     );
 
+    // Registrar estilos y scripts para las barras de niveles de bienvenida.
+    wp_register_style(
+        'cdb-bienvenida-niveles',
+        CDB_FORM_URL . 'assets/css/cdb-bienvenida-niveles.css',
+        array(),
+        '1.0.0'
+    );
+    wp_register_script(
+        'cdb-bienvenida-niveles',
+        CDB_FORM_URL . 'assets/js/cdb-bienvenida-niveles.js',
+        array(),
+        '1.0.0',
+        true
+    );
+
     // Encolar la hoja de estilos solo si el contenido incluye los shortcodes relevantes.
     if ( is_singular() ) {
         global $post;
         if ( has_shortcode( $post->post_content, 'cdb_bienvenida_empleado' ) || has_shortcode( $post->post_content, 'cdb_bienvenida_usuario' ) ) {
             wp_enqueue_style( 'cdb-form-bienvenida-empleado' );
+            wp_enqueue_style( 'cdb-bienvenida-niveles' );
+            wp_enqueue_script( 'cdb-bienvenida-niveles' );
         }
     }
 


### PR DESCRIPTION
## Summary
- Refactor employee welcome shortcode to display level bars for employees, employers and tutors with color overrides and scale markers.
- Enqueue dedicated stylesheet and animation script for the new bars.
- Add CSS and JS assets for responsive, animated level bars.

## Testing
- `php -l includes/shortcodes.php`
- `php -l public/enqueue.php`


------
https://chatgpt.com/codex/tasks/task_e_689753f42164832791e90f49c2334c8d