### PR TITLE
fix(bienvenida): barras por rol con animación y sin columna numérica

### DIFF
--- a/assets/css/cdb-bienvenida-niveles.css
+++ b/assets/css/cdb-bienvenida-niveles.css
@@ -9,9 +9,14 @@
 .cdb-niveles__scale .cdb-progress-marker { position: absolute; transform: translateX(-50%); font-size: 12px; font-weight: bold; }
 
 /* Filas */
-.cdb-niveles__row { display: grid; grid-template-columns: 120px 1fr min-content; align-items: center; gap: 12px; margin: 6px 0; }
+.cdb-niveles__row {
+  display: grid;
+  grid-template-columns: minmax(120px,160px) 1fr;
+  gap: 12px;
+  align-items: center;
+  margin: 6px 0;
+}
 .cdb-niveles__label { font-weight: 700; }
-.cdb-niveles__value { font-weight: 800; font-variant-numeric: tabular-nums; }
 
 /* Pista y relleno */
 .cdb-niveles__track { position: relative; height: 16px; border-radius: 999px; overflow: hidden; background: #eee; }
@@ -39,7 +44,7 @@
 
 /* Responsive */
 @media (max-width: 640px) {
-  .cdb-niveles__head,
-  .cdb-niveles__row { grid-template-columns: 100px 1fr min-content; }
+  .cdb-niveles__head { grid-template-columns: 100px 1fr; }
+  .cdb-niveles__row { grid-template-columns: minmax(100px,140px) 1fr; }
   .cdb-niveles__track { height: 14px; }
 }

--- a/assets/js/cdb-bienvenida-niveles.js
+++ b/assets/js/cdb-bienvenida-niveles.js
@@ -1,9 +1,8 @@
-(function(){
-  document.addEventListener('DOMContentLoaded', function(){
-    document.querySelectorAll('.cdb-niveles__fill').forEach(function(el){
-      // Forzar reflujo y activar animación
-      void el.offsetWidth;
-      el.classList.add('is-in');
-    });
+document.addEventListener('DOMContentLoaded', function(){
+  document.querySelectorAll('.cdb-niveles--bienvenida .cdb-niveles__fill').forEach(function(el){
+    // forzar reflow y animación
+    void el.offsetWidth;
+    el.classList.add('is-in');
   });
-})();
+});
+

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -406,21 +406,15 @@ function cdbf_render_head_niveles() {
  * @return string HTML generado.
  */
 function cdbf_render_barra_nivel( $label, $valor, $role_key ) {
-    $dec   = cdb_form_card_number_decimals();
     $empty = false;
+
     if ( $valor === null ) {
         $empty = true;
         $valor = 0;
     } else {
-        $valor = floatval( $valor );
-        if ( $valor < 0 ) {
-            $valor = 0;
-        } elseif ( $valor > 100 ) {
-            $valor = 100;
-        }
+        $valor = max( 0, min( 100, floatval( $valor ) ) );
     }
 
-    $formatted = number_format_i18n( $valor, $dec );
     $data_attr = $empty ? ' data-empty="1"' : '';
 
     ob_start();
@@ -429,10 +423,11 @@ function cdbf_render_barra_nivel( $label, $valor, $role_key ) {
       <div class="cdb-niveles__label"><?php echo esc_html( $label ); ?></div>
       <div class="cdb-niveles__bar">
         <div class="cdb-niveles__track">
-          <div class="cdb-niveles__fill" style="width:<?php echo esc_attr( $valor ); ?>%"></div>
+          <?php if ( ! $empty ) : ?>
+          <div class="cdb-niveles__fill" style="width:<?php echo esc_attr( $valor ); ?>%;"></div>
+          <?php endif; ?>
         </div>
       </div>
-      <div class="cdb-niveles__value"><?php echo esc_html( $formatted ); ?></div>
     </div>
     <?php
     return ob_get_clean();


### PR DESCRIPTION
## Summary
- Reuse single bar renderer for all roles with width clamping and empty state
- Animate level bars only within welcome component
- Simplify niveles grid to two columns and drop numeric value column

## Testing
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_689758536a388327a9cfd4049495b8f6