### PR TITLE
Ensure role score defaults and render zero-score bars

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -36,7 +36,7 @@ function cdb_obtener_fecha_ultima_valoracion( $empleado_id ) {
  * @return array Scores by role: ['empleado'=>float,'empleador'=>?float,'tutor'=>?float]
  */
 function cdb_form_get_graph_scores_by_role( int $empleado_id, bool $bypass_cache = false ): array {
-    $out = [ 'empleado' => 0.0, 'empleador' => null, 'tutor' => null ];
+    $out = [ 'empleado' => 0.0, 'empleador' => 0.0, 'tutor' => 0.0 ];
 
     if ( function_exists( 'cdb_grafica_get_scores_by_role' ) && $empleado_id > 0 ) {
         $data = cdb_grafica_get_scores_by_role( $empleado_id, [ 'bypass_cache' => $bypass_cache ] );

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -444,9 +444,7 @@ function cdbf_render_barra_nivel( $label, $score, $role_key, $width_pct = null, 
       <div class="cdb-niveles__label"><?php echo esc_html( $label ); ?></div>
       <div class="cdb-niveles__bar">
         <div class="cdb-niveles__track">
-          <?php if ( ! $empty ) : ?>
           <div class="cdb-niveles__fill" style="width:<?php echo esc_attr( $width_pct ); ?>%;"></div>
-          <?php endif; ?>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Initialize `empleador` and `tutor` scores to `0.0` in `cdb_form_get_graph_scores_by_role`
- Always output the progress bar fill element even when the score is zero

## Testing
- `php -l includes/helpers.php`
- `php -l includes/shortcodes.php`
- `php -r "define('ABSPATH', __DIR__ . '/'); function cdb_grafica_get_scores_by_role(\$id,\$opts){return ['empleado'=>80,'empleador'=>0,'tutor'=>100];} require 'includes/helpers.php'; \$scores=cdb_form_get_graph_scores_by_role(1); var_export(\$scores);"`
- `php -r "define('ABSPATH', __DIR__ . '/'); function esc_attr(\$s){return \$s;} function esc_html(\$s){return \$s;} function add_shortcode(){return null;} require 'includes/shortcodes.php'; echo cdbf_render_barra_nivel('Test', 0, 'test');"`


------
https://chatgpt.com/codex/tasks/task_e_68975fe7542083279245f88899054133