### PR TITLE
chore: improve responsive levels label

### DIFF
--- a/assets/css/cdb-bienvenida-niveles.css
+++ b/assets/css/cdb-bienvenida-niveles.css
@@ -56,7 +56,12 @@
 @media (max-width: 640px) {
   .cdb-niveles__head { grid-template-columns: 100px 1fr; }
   .cdb-niveles__row { grid-template-columns: minmax(110px, 160px) 1fr; }
-  .cdb-niveles__label { font-size: 0.95rem; }
+  .cdb-niveles__label {
+    font-size: 0.95rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   .cdb-niveles__track { height: 14px; }
 }
 
@@ -64,9 +69,21 @@
   .cdb-niveles__row {
     grid-template-columns: 1fr;
     grid-auto-rows: auto;
+    gap: 6px;
+  }
+  .cdb-niveles__label {
+    font-size: 0.9rem;
   }
 }
 
 @supports (hyphens:auto){
   .cdb-niveles__label { white-space: normal; hyphens: auto; overflow: visible; text-overflow: initial; }
+  @media (max-width: 640px) {
+    .cdb-niveles__label {
+      white-space: nowrap;
+      hyphens: none;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- ensure level labels truncate with ellipsis on small screens
- stack label and bar with tighter gap and smaller font on very narrow screens

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b25abb7883278063b8a4c49f9040