### PR TITLE
Map score totals to bar percentages and unify bar styling

### DIFF
--- a/assets/css/cdb-bienvenida-niveles.css
+++ b/assets/css/cdb-bienvenida-niveles.css
@@ -34,7 +34,7 @@
 
 /* 5) Blindaje: nada de flex que ensanche la barra/fill */
 .cdb-niveles__bar{ display:block; margin:0; padding:0; }
-.cdb-niveles__track{ display:block; position:relative; width:100%; height:16px; border-radius:999px; overflow:hidden; }
+.cdb-niveles__track{ display:block; position:relative; width:100%; height:16px; border-radius:999px; overflow:hidden; background:#e9e9e9; }
 .cdb-niveles__fill{ display:block; height:100%; width:0; max-width:100%; flex:0 0 auto !important; transform-origin:left center; transform:scaleX(0); transition:transform .9s ease-in-out; }
 .cdb-niveles__fill.is-in{ transform:scaleX(1); }
 
@@ -44,14 +44,9 @@
 .cdb-niveles__scale .cdb-progress-marker { position: absolute; transform: translateX(-50%); font-size: 12px; font-weight: bold; }
 
 /* Colores de pista y relleno */
-.cdb-niveles__row--empleados .cdb-niveles__track   { background: #e0e0e0; }
-.cdb-niveles__row--empleados .cdb-niveles__fill    { background: var(--cdb-color-empleado-fill, #9aa0a6); }
-
-.cdb-niveles__row--empleadores .cdb-niveles__track { background: #555555; }
-.cdb-niveles__row--empleadores .cdb-niveles__fill  { background: var(--cdb-color-empleador-fill, #777777); }
-
-.cdb-niveles__row--tutores .cdb-niveles__track     { background: #cdb888; }
-.cdb-niveles__row--tutores .cdb-niveles__fill      { background: var(--cdb-color-tutor-fill, #cdb888); }
+.cdb-niveles__row--empleados .cdb-niveles__fill{ background:var(--cdb-color-empleado-fill,#9aa0a6); }
+.cdb-niveles__row--empleadores .cdb-niveles__fill{ background:var(--cdb-color-empleador-fill,#777777); }
+.cdb-niveles__row--tutores .cdb-niveles__fill{ background:var(--cdb-color-tutor-fill,#cdb888); }
 
 /* Estado sin valoraciones */
 .cdb-niveles__row[data-empty="1"] .cdb-niveles__track {

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -320,9 +320,9 @@ function cdb_bienvenida_empleado_shortcode() {
             $color_empleador_fill  = '';
             $color_tutor_fill      = '';
             if ( function_exists( 'cdb_grafica_get_color_by_role' ) ) {
-                $color_empleado_fill  = cdb_grafica_get_color_by_role( 'empleado' );
-                $color_empleador_fill = cdb_grafica_get_color_by_role( 'empleador' );
-                $color_tutor_fill     = cdb_grafica_get_color_by_role( 'tutor' );
+                $color_empleado_fill  = cdb_grafica_get_color_by_role( 'empleado', 'background' );
+                $color_empleador_fill = cdb_grafica_get_color_by_role( 'empleador', 'background' );
+                $color_tutor_fill     = cdb_grafica_get_color_by_role( 'tutor', 'background' );
             }
 
             if ( $color_empleado_fill || $color_empleador_fill || $color_tutor_fill ) {
@@ -425,13 +425,25 @@ function cdbf_to_float( $v ) {
     return floatval( $v );
 }
 
+/**
+ * Convierte la puntuación total por rol en un porcentaje de anchura.
+ *
+ * El valor de entrada representa el total obtenido por un rol específico
+ * (aproximadamente entre 0 y 40). El resultado es un porcentaje entre 0 y 100
+ * que se utiliza para ajustar la anchura de la barra correspondiente.
+ *
+ * @param float|int $score Puntuación total por rol (≈0–40).
+ * @return float Porcentaje de anchura (0–100).
+ */
 function cdbf_width_pct_from_score( $score ) {
     // Reutiliza la normalización de la barra original si está disponible.
     if ( function_exists( 'cdb_grafica_get_width_pct_from_score' ) ) {
         return (float) cdb_grafica_get_width_pct_from_score( $score );
     }
 
-    return max( 0, min( 100, floatval( $score ) ) );
+    $max = (float) apply_filters( 'cdb_form_niveles_max_score', 40 ); // total esperado por rol (≈10 grupos * 4)
+    $pct = ( $max > 0 ) ? ( $score / $max ) * 100 : 0;
+    return max( 0, min( 100, round( $pct, 2 ) ) );
 }
 
 function cdbf_render_barra_nivel( $label, $score, $role_key, $width_pct = null, $empty = false ) {


### PR DESCRIPTION
## Summary
- Normalize role scores against a configurable max (default 40) to produce 0–100% widths
- Read role fill colors from `cdb_grafica_get_color_by_role` when available
- Unify bar track background and keep role-specific fills for better contrast

## Testing
- `php -l includes/shortcodes.php`
- `php /tmp/test_width.php`


------
https://chatgpt.com/codex/tasks/task_e_6898f31f89b0832792d7a6dc16c53d6f