### PR TITLE
Force 0–100 level bar scaling and align markers

### DIFF
--- a/assets/css/cdb-bienvenida-niveles.css
+++ b/assets/css/cdb-bienvenida-niveles.css
@@ -9,10 +9,24 @@
 /* 2) Cabecera y filas comparten EXACTAMENTE el mismo grid */
 .cdb-niveles__head,
 .cdb-niveles__row{
-  display: grid;
+  display:grid;
   grid-template-columns: var(--cdb-label-col) 1fr; /* pista fija y estrecha */
+  align-items:center;
   gap: var(--cdb-gap);
-  align-items: center;
+}
+
+.cdb-niveles__head-label{ grid-column:1; }
+.cdb-niveles__scale{
+  grid-column:2;
+  position:relative;  /* referencia para left:% */
+  width:100%;
+  height:18px;       /* similar a la pista */
+}
+.cdb-progress-marker{
+  position:absolute;
+  top:0;
+  transform:translateX(-50%); /* centrar texto en el punto */
+  font-size:12px;
 }
 
 /* 3) Etiquetas sin negrita y más ceñidas */
@@ -39,9 +53,7 @@
 .cdb-niveles__fill.is-in{ transform:scaleX(1); }
 
 /* Escala y marcas */
-.cdb-niveles__scale { position: relative; height: 24px; }
 /* Reutiliza las marcas existentes de la barra original. Si no existen como clases sueltas, clónalas dentro de este contenedor. */
-.cdb-niveles__scale .cdb-progress-marker { position: absolute; transform: translateX(-50%); font-size: 12px; font-weight: bold; }
 
 /* Colores de pista y relleno */
 .cdb-niveles__row--empleados .cdb-niveles__fill{ background:var(--cdb-color-empleado-fill,#9aa0a6); }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -111,7 +111,19 @@ function cdb_form_card_labels(): array {
     return (array) apply_filters( 'cdb_form_card_labels', cdb_form_card_default_labels() );
 }
 
-// Tratar el score de entrada como porcentaje 0–100 para las barras de nivel.
-add_filter( 'cdb_form_niveles_max_score', function( $max ) {
-    return 100;
+// Fuerza que las barras interpreten el score como porcentaje 0–100.
+add_filter( 'cdb_form_niveles_force_pct', '__return_true' );
+
+// Mapa de marcadores 0–100.
+add_filter( 'cdb_form_niveles_scale_map', function( $map ) {
+    return [
+        '0'   => 20,
+        '1'   => 30,
+        '1.1' => 40,
+        '2'   => 50,
+        '2.1' => 60,
+        '3'   => 70,
+        '3.1' => 80,
+        '4'   => 100,
+    ];
 } );

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -451,14 +451,24 @@ function cdbf_to_float( $v ) {
  * @param float|int $score Puntuación total por rol (≈0–40).
  * @return float Porcentaje de anchura (0–100).
  */
+/**
+ * Devuelve el ancho (%) de la barra a partir de un valor que ya es 0–100.
+ * Se puede desactivar el forzado vía el filtro 'cdb_form_niveles_force_pct'.
+ */
 function cdbf_width_pct_from_score( $score ) {
-    // Reutiliza la normalización de la barra original si está disponible.
-    if ( function_exists( 'cdb_grafica_get_width_pct_from_score' ) ) {
-        return (float) cdb_grafica_get_width_pct_from_score( $score );
+    $force_pct = apply_filters( 'cdb_form_niveles_force_pct', true ); // forzar por defecto
+    $val       = (float) $score;
+
+    if ( $force_pct ) {
+        return max( 0, min( 100, round( $val, 2 ) ) );
     }
 
-    $max = (float) apply_filters( 'cdb_form_niveles_max_score', 40 ); // total esperado por rol (≈10 grupos * 4)
-    $pct = ( $max > 0 ) ? ( $score / $max ) * 100 : 0;
+    // Compatibilidad (si se desactiva el forzado):
+    if ( function_exists( 'cdb_grafica_get_width_pct_from_score' ) ) {
+        return (float) cdb_grafica_get_width_pct_from_score( $val );
+    }
+    $max = (float) apply_filters( 'cdb_form_niveles_max_score', 40 );
+    $pct = ( $max > 0 ) ? ( $val / $max ) * 100 : 0;
     return max( 0, min( 100, round( $pct, 2 ) ) );
 }
 


### PR DESCRIPTION
## Summary
- Treat level bar scores as direct percentages via new `cdbf_width_pct_from_score` logic
- Force 0–100 interpretation and explicit scale map through public filters
- Align header grid and marker container with level bar layout

## Testing
- `php -l includes/shortcodes.php`
- `php -l includes/helpers.php`
- `npx stylelint assets/css/cdb-bienvenida-niveles.css` *(fails: 403 Forbidden)*
- `php -r 'define("ABSPATH", __DIR__); function add_shortcode($tag,$cb){return;} function apply_filters($tag,$value){return $value;} require "includes/shortcodes.php"; $tests=[35,42,14,56,82]; foreach($tests as $s){ $w=cdbf_width_pct_from_score($s); $lvl=cdbf_level_from_pct($w); echo "$s => $w% level=$lvl\n"; }'`

------
https://chatgpt.com/codex/tasks/task_e_68991a33f4c48327b651e775c40f1c7e