### PR TITLE
Improve responsive rendering for niveles scale

### DIFF
--- a/assets/css/cdb-bienvenida-niveles.css
+++ b/assets/css/cdb-bienvenida-niveles.css
@@ -20,14 +20,19 @@
   grid-column:2;
   position:relative;  /* referencia para left:% */
   width:100%;
-  height:18px;       /* similar a la pista */
+  height:30px;       /* espacio para 2 filas de marcadores */
 }
 .cdb-progress-marker{
   position:absolute;
   top:0;
-  transform:translateX(-50%); /* centrar texto en el punto */
+  transform: translateX(-50%); /* centrar texto en el punto */
+  line-height:1;
   font-size:12px;
+  white-space:nowrap;
 }
+.cdb-progress-marker.is-start{ transform: translateX(0); }
+.cdb-progress-marker.is-end{ transform: translateX(-100%); }
+.cdb-progress-marker--secondary{ top:16px; opacity:.9; font-size:11px; }
 
 /* 3) Etiquetas sin negrita y más ceñidas */
 .cdb-niveles__head-label,
@@ -81,15 +86,21 @@
 @media (max-width: 640px){
   .cdb-niveles--bienvenida{ --cdb-label-col: 100px; --cdb-gap: 5px; }
   .cdb-niveles__label{ font-size: 0.85rem; }
+  .cdb-progress-marker--secondary{ display:none; }
+  .cdb-progress-marker{ font-size:11px; }
+  .cdb-niveles__scale{ height: 20px; }
 }
 
-/* 7) Móvil muy estrecho: 1 columna en cabecera y filas (evita desajustes) */
+@media (max-width: 380px){
+  .cdb-progress-marker{ display:none; }
+  .cdb-progress-marker[data-label="0"],
+  .cdb-progress-marker[data-label="2"],
+  .cdb-progress-marker[data-label="4"]{ display:block; }
+  .cdb-progress-marker{ font-size:10px; }
+}
+
 @media (max-width: 480px){
-  .cdb-niveles__head,
-  .cdb-niveles__row{
-    grid-template-columns: 1fr;  /* etiqueta/“Nivel” arriba, barra/escala abajo */
-    gap: 6px;
-  }
+  .cdb-niveles--bienvenida{ --cdb-label-col: 88px; }
 }
 
 /* Blindaje extra para evitar márgenes globales */

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -411,19 +411,38 @@ function cdbf_render_head_niveles() {
         '4'   => '#07ada8',
     ];
 
+    $primaries = apply_filters( 'cdb_form_niveles_primary_labels', [ '0', '1', '2', '3', '4' ] );
+
     ob_start();
     ?>
     <div class="cdb-niveles__head">
       <div class="cdb-niveles__head-label"><?php esc_html_e( 'Nivel', 'cdb-form' ); ?></div>
       <div class="cdb-niveles__scale">
-        <?php foreach ( $map as $label => $pct ) : ?>
-        <div class="cdb-progress-marker" style="left: <?php echo esc_attr( $pct ); ?>%; color: <?php echo esc_attr( $colors[ $label ] ?? '#000' ); ?>;"><?php echo esc_html( $label ); ?></div>
+        <?php foreach ( $map as $label => $pct ) :
+            $extra_classes = [];
+            if ( ! in_array( $label, $primaries, true ) ) {
+                $extra_classes[] = 'cdb-progress-marker--secondary';
+            }
+            if ( $pct <= 0 ) {
+                $extra_classes[] = 'is-start';
+            }
+            if ( $pct >= 100 ) {
+                $extra_classes[] = 'is-end';
+            }
+            $extra_classes = implode( ' ', $extra_classes );
+        ?>
+        <div class="cdb-progress-marker <?php echo esc_attr( $extra_classes ); ?>"
+             data-label="<?php echo esc_attr( $label ); ?>"
+             style="left: <?php echo esc_attr( $pct ); ?>%; color: <?php echo esc_attr( $colors[ $label ] ?? '#000' ); ?>;">
+            <?php echo esc_html( $label ); ?>
+        </div>
         <?php endforeach; ?>
       </div>
     </div>
     <?php
     return ob_get_clean();
 }
+
 
 /**
  * Renderiza una fila de barra de nivel.


### PR DESCRIPTION
## Summary
- Mark level scale markers as primary or secondary and anchor start/end points
- Align header markers with bar grid and support multi-line layout
- Simplify scale markers on small screens for better readability

## Testing
- `php -l includes/shortcodes.php`
- `npx stylelint assets/css/cdb-bienvenida-niveles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689921a2e9708327ae24cd3f5da2d4d6