### PR TITLE
Ensure markers stay on one line

### DIFF
--- a/assets/css/cdb-bienvenida-niveles.css
+++ b/assets/css/cdb-bienvenida-niveles.css
@@ -110,3 +110,62 @@
 .cdb-niveles__bar,
 .cdb-niveles__track{ margin-block: 0; }
 
+
+/* ---------- Niveles: marcadores en una sola línea ---------- */
+.cdb-niveles__head{
+  display:grid;
+  grid-template-columns: var(--cdb-label-col) 1fr;
+  align-items:center;
+  gap: var(--cdb-gap);
+}
+.cdb-niveles__head-label{ grid-column:1; }
+.cdb-niveles__scale{
+  grid-column:2;
+  position:relative;
+  width:100%;
+  height:22px;
+}
+
+.cdb-progress-marker{
+  position:absolute;
+  top:0;
+  line-height:1;
+  white-space:nowrap;
+  font-variant-numeric: tabular-nums;
+  --marker-scale:1;
+  --tx:-50%;
+  transform: translateX(var(--tx)) scale(var(--marker-scale));
+  transform-origin: top center;
+  font-size:12px;
+}
+.cdb-progress-marker.is-start{
+  --tx:0;
+  transform-origin: top left;
+}
+.cdb-progress-marker.is-end{
+  --tx:-100%;
+  transform-origin: top right;
+}
+
+/* Todos los marcadores en la misma línea */
+.cdb-progress-marker--secondary{ top:0; font-size:inherit; }
+
+@media (max-width: 640px){
+  .cdb-niveles--bienvenida{ --cdb-label-col: 88px; }
+  .cdb-progress-marker{
+    display:block;
+    font-size:11px;
+    --marker-scale: clamp(0.70, 100vw / 640, 0.95);
+    letter-spacing:.02em;
+  }
+  .cdb-progress-marker--secondary{ display:block; }
+}
+
+@media (max-width: 400px){
+  .cdb-progress-marker{
+    display:block;
+    font-size:10px;
+    --marker-scale: clamp(0.60, 100vw / 400, 0.85);
+  }
+}
+

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -400,18 +400,6 @@ function cdbf_render_head_niveles() {
         '3.1' => 80,
         '4'   => 100,
     ] );
-    $colors = [
-        '0'   => '#c0c0c0',
-        '1'   => '#c0c0c0',
-        '1.1' => '#c0c0c0',
-        '2'   => '#000',
-        '2.1' => '#000',
-        '3'   => '#dbc63d',
-        '3.1' => '#dbc63d',
-        '4'   => '#07ada8',
-    ];
-
-    $primaries = apply_filters( 'cdb_form_niveles_primary_labels', [ '0', '1', '2', '3', '4' ] );
 
     ob_start();
     ?>
@@ -419,22 +407,12 @@ function cdbf_render_head_niveles() {
       <div class="cdb-niveles__head-label"><?php esc_html_e( 'Nivel', 'cdb-form' ); ?></div>
       <div class="cdb-niveles__scale">
         <?php foreach ( $map as $label => $pct ) :
-            $extra_classes = [];
-            if ( ! in_array( $label, $primaries, true ) ) {
-                $extra_classes[] = 'cdb-progress-marker--secondary';
-            }
-            if ( $pct <= 0 ) {
-                $extra_classes[] = 'is-start';
-            }
-            if ( $pct >= 100 ) {
-                $extra_classes[] = 'is-end';
-            }
-            $extra_classes = implode( ' ', $extra_classes );
+            $edge = ( $pct <= 0 ) ? ' is-start' : ( ( $pct >= 100 ) ? ' is-end' : '' );
         ?>
-        <div class="cdb-progress-marker <?php echo esc_attr( $extra_classes ); ?>"
-             data-label="<?php echo esc_attr( $label ); ?>"
-             style="left: <?php echo esc_attr( $pct ); ?>%; color: <?php echo esc_attr( $colors[ $label ] ?? '#000' ); ?>;">
-            <?php echo esc_html( $label ); ?>
+        <div class="cdb-progress-marker<?php echo esc_attr( $edge ); ?>"
+             data-label="<?php echo esc_attr( (string) $label ); ?>"
+             style="left: <?php echo esc_attr( (string) $pct ); ?>%;">
+          <?php echo esc_html( (string) $label ); ?>
         </div>
         <?php endforeach; ?>
       </div>


### PR DESCRIPTION
## Summary
- Simplify `cdbf_render_head_niveles` markers and add edge classes
- Add CSS for single-line marker layout with adaptive scaling across breakpoints

## Testing
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_689936336f248327b74ccc035db5e41d