### PR TITLE
Remove progress marker ticks and adjust scale height

### DIFF
--- a/assets/css/cdb-bienvenida-niveles.css
+++ b/assets/css/cdb-bienvenida-niveles.css
@@ -165,20 +165,6 @@
 
 .cdb-progress-marker[data-label="4"]{ color: var(--niv-max); }
 
-.cdb-progress-marker::after{
-  content:"";
-  position:absolute;
-  left:50%;
-  transform:translateX(-50%);
-  bottom:-6px;
-  width:6px; height:6px; border-radius:50%;
-  background: currentColor;   /* usa el color del marcador */
-  opacity:.9;
-}
-
-@media (max-width:640px){
-  .cdb-progress-marker::after{ width:5px; height:5px; bottom:-5px; }
-}
 
 /* Todos los marcadores en la misma línea */
 .cdb-progress-marker--secondary{ top:0; font-size:inherit; }
@@ -200,5 +186,11 @@
     font-size:10px;
     --marker-scale: clamp(0.60, 100vw / 400, 0.85);
   }
+}
+
+/* Ajuste de altura al no haber ticks */
+.cdb-niveles__scale{ height: 20px; }
+@media (max-width: 640px){
+  .cdb-niveles__scale{ height: 18px; }
 }
 


### PR DESCRIPTION
## Summary
- Remove CSS pseudo-element for progress marker ticks
- Tighten scale height for cleaner layout without ticks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68993bd19b3883279225215e3bb8c62b