### PR TITLE
Use custom manage_cdb_forms capability in admin pages

### DIFF
--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -16,7 +16,7 @@ function cdb_form_mensajes_admin_menu() {
         'cdb-form',
         __( 'Configuración de Mensajes y Avisos', 'cdb-form' ),
         __( 'Configuración de Mensajes y Avisos', 'cdb-form' ),
-        'manage_options',
+        'manage_cdb_forms',
         'cdb-form-config-mensajes',
         'cdb_form_config_mensajes_page'
     );
@@ -27,7 +27,7 @@ add_action( 'admin_menu', 'cdb_form_mensajes_admin_menu' );
  * Renderiza la página de opciones y guarda los valores.
  */
 function cdb_form_config_mensajes_page() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can( 'manage_cdb_forms' ) ) {
         return;
     }
 

--- a/admin/diseno-empleado.php
+++ b/admin/diseno-empleado.php
@@ -11,7 +11,7 @@ function cdb_form_admin_menu() {
     add_menu_page(
         __( 'CdB Form', 'cdb-form' ),
         __( 'CdB Form', 'cdb-form' ),
-        'manage_options',
+        'manage_cdb_forms',
         'cdb-form',
         'cdb_form_admin_page',
         'dashicons-forms'
@@ -21,7 +21,7 @@ function cdb_form_admin_menu() {
         'cdb-form',
         __( 'Configuración Crear Empleado', 'cdb-form' ),
         __( 'Configuración Crear Empleado', 'cdb-form' ),
-        'manage_options',
+        'manage_cdb_forms',
         'cdb-form-disenio-empleado',
         'cdb_form_disenio_empleado_page'
     );
@@ -39,7 +39,7 @@ function cdb_form_admin_page() {
  * Render admin page and handle form submission.
  */
 function cdb_form_disenio_empleado_page() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can( 'manage_cdb_forms' ) ) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- Replace `manage_options` with `manage_cdb_forms` in admin menu and page checks
- Ensure editors and authors with `manage_cdb_forms` can access plugin admin pages

## Testing
- `php -l admin/diseno-empleado.php`
- `php -l admin/config-mensajes.php`
- `php -l includes/capabilities.php`


------
https://chatgpt.com/codex/tasks/task_e_68acfc84e4d08327927e647d2c7d91bf