### PR TITLE
Centraliza el registro del menú en un único archivo

### DIFF
--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -11,17 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * en la experiencia de usuario de CdB. Está preparado para añadidos
  * futuros mediante una estructura dinámica basada en arrays.
  */
-function cdb_form_mensajes_admin_menu() {
-    add_submenu_page(
-        'cdb-form',
-        __( 'Configuración de Mensajes y Avisos', 'cdb-form' ),
-        __( 'Configuración de Mensajes y Avisos', 'cdb-form' ),
-        'manage_cdb_forms',
-        'cdb-form-config-mensajes',
-        'cdb_form_config_mensajes_page'
-    );
-}
-add_action( 'admin_menu', 'cdb_form_mensajes_admin_menu' );
 
 /**
  * Renderiza la página de opciones y guarda los valores.

--- a/admin/diseno-empleado.php
+++ b/admin/diseno-empleado.php
@@ -5,41 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Add main admin menu and submenus.
- */
-function cdb_form_admin_menu() {
-    add_menu_page(
-        __( 'CdB Form', 'cdb-form' ),
-        __( 'CdB Form', 'cdb-form' ),
-        'manage_cdb_forms',
-        'cdb-form',
-        'cdb_form_admin_page',
-        'dashicons-forms'
-    );
-
-    remove_submenu_page( 'cdb-form', 'cdb-form' );
-
-    add_submenu_page(
-        'cdb-form',
-        __( 'CdB Form', 'cdb-form' ),
-        __( 'CdB Form', 'cdb-form' ),
-        'manage_cdb_forms',
-        'cdb-form',
-        'cdb_form_admin_page'
-    );
-
-    add_submenu_page(
-        'cdb-form',
-        __( 'Configuración Crear Empleado', 'cdb-form' ),
-        __( 'Configuración Crear Empleado', 'cdb-form' ),
-        'manage_cdb_forms',
-        'cdb-form-disenio-empleado',
-        'cdb_form_disenio_empleado_page'
-    );
-}
-add_action( 'admin_menu', 'cdb_form_admin_menu' );
-
-/**
  * Callback for the main CdB Form page.
  */
 function cdb_form_admin_page() {

--- a/admin/menu.php
+++ b/admin/menu.php
@@ -1,0 +1,51 @@
+<?php
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register main plugin menu and all submenus.
+ */
+function cdb_form_register_menus() {
+    add_menu_page(
+        __( 'CdB Form', 'cdb-form' ),
+        __( 'CdB Form', 'cdb-form' ),
+        'manage_cdb_forms',
+        'cdb-form',
+        'cdb_form_admin_page',
+        'dashicons-forms'
+    );
+
+    // Remove duplicate link to top-level page.
+    remove_submenu_page( 'cdb-form', 'cdb-form' );
+
+    add_submenu_page(
+        'cdb-form',
+        __( 'CdB Form', 'cdb-form' ),
+        __( 'CdB Form', 'cdb-form' ),
+        'manage_cdb_forms',
+        'cdb-form',
+        'cdb_form_admin_page'
+    );
+
+    add_submenu_page(
+        'cdb-form',
+        __( 'Configuración Crear Empleado', 'cdb-form' ),
+        __( 'Configuración Crear Empleado', 'cdb-form' ),
+        'manage_cdb_forms',
+        'cdb-form-disenio-empleado',
+        'cdb_form_disenio_empleado_page'
+    );
+
+    add_submenu_page(
+        'cdb-form',
+        __( 'Configuración de Mensajes y Avisos', 'cdb-form' ),
+        __( 'Configuración de Mensajes y Avisos', 'cdb-form' ),
+        'manage_cdb_forms',
+        'cdb-form-config-mensajes',
+        'cdb_form_config_mensajes_page'
+    );
+}
+add_action( 'admin_menu', 'cdb_form_register_menus' );
+

--- a/includes/init.php
+++ b/includes/init.php
@@ -23,6 +23,7 @@ require_once CDB_FORM_PATH . 'includes/messages.php';
 
 // Cargar scripts y estilos para el admin y frontend
 require_once CDB_FORM_PATH . 'admin/enqueue.php';
+require_once CDB_FORM_PATH . 'admin/menu.php';
 require_once CDB_FORM_PATH . 'admin/diseno-empleado.php';
 require_once CDB_FORM_PATH . 'admin/config-mensajes.php';
 require_once CDB_FORM_PATH . 'public/enqueue.php';


### PR DESCRIPTION
## Summary
- Centraliza la creación del menú de administración en `admin/menu.php`.
- Elimina los hooks `admin_menu` duplicados en `diseno-empleado.php` y `config-mensajes.php`.
- Carga el nuevo registro de menús desde `includes/init.php`.

## Testing
- `php -l admin/menu.php`
- `php -l admin/diseno-empleado.php`
- `php -l admin/config-mensajes.php`
- `php -l includes/init.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad039cf7c483279c7da057f735935e