### PR TITLE
Add menu position and shorten admin submenu titles

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -14,7 +14,8 @@ function cdb_form_register_menus() {
         'manage_cdb_forms',
         'cdb-form',
         'cdb_form_admin_page',
-        'dashicons-forms'
+        'dashicons-forms',
+        26
     );
 
     // Remove duplicate link to top-level page.
@@ -32,7 +33,7 @@ function cdb_form_register_menus() {
     add_submenu_page(
         'cdb-form',
         __( 'Configuración Crear Empleado', 'cdb-form' ),
-        __( 'Configuración Crear Empleado', 'cdb-form' ),
+        __( 'Diseño del formulario', 'cdb-form' ),
         'manage_cdb_forms',
         'cdb-form-disenio-empleado',
         'cdb_form_disenio_empleado_page'
@@ -41,7 +42,7 @@ function cdb_form_register_menus() {
     add_submenu_page(
         'cdb-form',
         __( 'Configuración de Mensajes y Avisos', 'cdb-form' ),
-        __( 'Configuración de Mensajes y Avisos', 'cdb-form' ),
+        __( 'Mensajes y avisos', 'cdb-form' ),
         'manage_cdb_forms',
         'cdb-form-config-mensajes',
         'cdb_form_config_mensajes_page'

--- a/languages/cdb-form.pot
+++ b/languages/cdb-form.pot
@@ -889,3 +889,11 @@ msgstr ""
 #: admin/config-mensajes.php:295
 msgid "Mostrar aviso"
 msgstr ""
+
+#: admin/menu.php:36
+msgid "Diseño del formulario"
+msgstr ""
+
+#: admin/menu.php:45
+msgid "Mensajes y avisos"
+msgstr ""

--- a/languages/es_ES.po
+++ b/languages/es_ES.po
@@ -889,3 +889,11 @@ msgstr "Oculto"
 #: admin/config-mensajes.php:295
 msgid "Mostrar aviso"
 msgstr "Mostrar aviso"
+
+#: admin/menu.php:36
+msgid "Diseño del formulario"
+msgstr "Diseño del formulario"
+
+#: admin/menu.php:45
+msgid "Mensajes y avisos"
+msgstr "Mensajes y avisos"


### PR DESCRIPTION
## Summary
- Set CdB Form top-level menu position to 26
- Simplify submenu titles to "Diseño del formulario" and "Mensajes y avisos"
- Update translation templates for new menu labels

## Testing
- `php -l admin/menu.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad056e5a888327be0345ceb25ccc88