### PR TITLE
Position CdB Form menu at top of admin sidebar

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -15,7 +15,7 @@ function cdb_form_register_menus() {
         'cdb-form',
         'cdb_form_admin_page',
         'dashicons-forms',
-        26
+        3
     );
 
     // Remove duplicate link to top-level page.


### PR DESCRIPTION
## Summary
- Move CdB Form plugin menu to the top of WordPress admin by setting menu position weight to 3

## Testing
- `php -l admin/menu.php`

------
https://chatgpt.com/codex/tasks/task_e_68acf8a58230832799a80adaf6d5f999