### PR TITLE
Avoid redundant submenu entry for CdB Form

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -18,18 +18,6 @@ function cdb_form_register_menus() {
         3
     );
 
-    // Remove duplicate link to top-level page.
-    remove_submenu_page( 'cdb-form', 'cdb-form' );
-
-    add_submenu_page(
-        'cdb-form',
-        __( 'CdB Form', 'cdb-form' ),
-        __( 'CdB Form', 'cdb-form' ),
-        'manage_cdb_forms',
-        'cdb-form',
-        'cdb_form_admin_page'
-    );
-
     add_submenu_page(
         'cdb-form',
         __( 'Configuración Crear Empleado', 'cdb-form' ),


### PR DESCRIPTION
## Summary
- Remove unnecessary submenu removal and re-addition
- Register only required "Diseño del formulario" and "Mensajes y avisos" submenus

## Testing
- `php -l admin/menu.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad180c24548327b95c12eb5c717cfc