### PR TITLE
Add navigation tabs between design and messages pages

### DIFF
--- a/admin/config-mensajes.php
+++ b/admin/config-mensajes.php
@@ -231,9 +231,16 @@ function cdb_form_config_mensajes_page() {
             $mensaje_guardado = __( 'Opciones guardadas.', 'cdb-form' );
         }
     }
+    $current_page = isset( $_GET['page'] ) ? sanitize_key( $_GET['page'] ) : '';
+    $disenio_url  = admin_url( 'admin.php?page=cdb-form-disenio-empleado' );
+    $mensajes_url = admin_url( 'admin.php?page=cdb-form-config-mensajes' );
     ?>
     <div class="wrap">
         <h1><?php esc_html_e( 'Configuración de Mensajes y Avisos', 'cdb-form' ); ?></h1>
+        <h2 class="nav-tab-wrapper">
+            <a href="<?php echo esc_url( $disenio_url ); ?>" class="nav-tab<?php echo ( 'cdb-form-disenio-empleado' === $current_page ) ? ' nav-tab-active' : ''; ?>"><?php esc_html_e( 'Diseño del formulario', 'cdb-form' ); ?></a>
+            <a href="<?php echo esc_url( $mensajes_url ); ?>" class="nav-tab<?php echo ( 'cdb-form-config-mensajes' === $current_page ) ? ' nav-tab-active' : ''; ?>"><?php esc_html_e( 'Mensajes y avisos', 'cdb-form' ); ?></a>
+        </h2>
         <p><?php esc_html_e( 'Este panel centraliza la gestión de mensajes/avisos de la experiencia de usuario CdB.', 'cdb-form' ); ?></p>
         <div class="notice notice-info"><p><?php esc_html_e( 'Si dejas un campo vacío se mostrará el texto por defecto', 'cdb-form' ); ?></p></div>
         <?php if ( $mensaje_guardado ) :

--- a/admin/diseno-empleado.php
+++ b/admin/diseno-empleado.php
@@ -192,10 +192,17 @@ function cdb_form_disenio_empleado_page() {
         echo '<div class="updated"><p>' . esc_html__( 'Opciones guardadas.', 'cdb-form' ) . '</p></div>';
     }
 
-    $values = wp_parse_args( get_option( 'cdb_form_disenio_empleado' ), $defaults );
+    $values       = wp_parse_args( get_option( 'cdb_form_disenio_empleado' ), $defaults );
+    $current_page = isset( $_GET['page'] ) ? sanitize_key( $_GET['page'] ) : '';
+    $disenio_url  = admin_url( 'admin.php?page=cdb-form-disenio-empleado' );
+    $mensajes_url = admin_url( 'admin.php?page=cdb-form-config-mensajes' );
     ?>
     <div class="wrap">
         <h1><?php esc_html_e( 'Configuración Crear Empleado', 'cdb-form' ); ?></h1>
+        <h2 class="nav-tab-wrapper">
+            <a href="<?php echo esc_url( $disenio_url ); ?>" class="nav-tab<?php echo ( 'cdb-form-disenio-empleado' === $current_page ) ? ' nav-tab-active' : ''; ?>"><?php esc_html_e( 'Diseño del formulario', 'cdb-form' ); ?></a>
+            <a href="<?php echo esc_url( $mensajes_url ); ?>" class="nav-tab<?php echo ( 'cdb-form-config-mensajes' === $current_page ) ? ' nav-tab-active' : ''; ?>"><?php esc_html_e( 'Mensajes y avisos', 'cdb-form' ); ?></a>
+        </h2>
         <p><?php esc_html_e( 'Configura los estilos del formulario de empleado mostrado en el frontend. Estos cambios no afectan a otros formularios.', 'cdb-form' ); ?></p>
         <form method="post">
             <?php wp_nonce_field( 'cdb_form_disenio_empleado_save', 'cdb_form_disenio_empleado_nonce' ); ?>


### PR DESCRIPTION
## Summary
- add WordPress nav-tab menu linking design and messages settings pages
- highlight active page tab for better navigation

## Testing
- `php -l admin/diseno-empleado.php`
- `php -l admin/config-mensajes.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad1cc023988327852214aa2c4ef4a4